### PR TITLE
Add 404 error page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Stránka nebyla nalezena | Rekonstrukce Praha</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body class="home">
+  <div class="hero">
+    <div class="contact-top">
+      📞 <a href="tel:+420123456789" class="text-white text-decoration-none">+420 123 456 789</a>
+    </div>
+    <h1>Stránka nebyla nalezena</h1>
+    <p class="mb-4">Omlouváme se, ale požadovaná adresa neexistuje.</p>
+    <a href="/" class="btn btn-light">Zpět na úvodní stránku</a>
+  </div>
+
+<footer class="footer bg-light text-dark py-5 mt-5 border-top">
+  <div class="container">
+    <div class="row">
+      <!-- Levý sloupec -->
+      <div class="col-md-4 mb-4">
+        <h6 class="text-uppercase fw-bold">Stránky</h6>
+        <ul class="list-unstyled small">
+          <li><a href="./" class="text-decoration-none text-muted">Úvod</a></li>
+          <li><a href="./rekonstrukce-bytu-praha/" class="text-decoration-none text-muted">Rekonstrukce bytů</a></li>
+          <li><a href="./rekonstrukce-koupelny-praha/" class="text-decoration-none text-muted">Koupelny</a></li>
+          <li><a href="./elektroinstalace-praha/" class="text-decoration-none text-muted">Elektroinstalace</a></li>
+          <li><a href="./obkladacske-prace-praha/" class="text-decoration-none text-muted">Obklady</a></li>
+        </ul>
+      </div>
+
+      <!-- Střední sloupec -->
+      <div class="col-md-4 mb-4">
+        <h6 class="text-uppercase fw-bold">Další služby</h6>
+        <ul class="list-unstyled small">
+          <li><a href="./kosmeticky-remont-praha/" class="text-decoration-none text-muted">Kosmetické opravy</a></li>
+          <li><a href="./zatepleni-fasady-praha/" class="text-decoration-none text-muted">Zateplení fasád</a></li>
+          <li><a href="./rekonstrukce-kancelari-praha/" class="text-decoration-none text-muted">Kanceláře</a></li>
+          <li><a href="./hodinovy-manzel-praha/" class="text-decoration-none text-muted">Hodinový manžel</a></li>
+          <li><a href="./stukovani-omitky-praha/" class="text-decoration-none text-muted">Omítky</a></li>
+        </ul>
+      </div>
+
+      <!-- Pravý sloupec -->
+      <div class="col-md-4">
+        <h6 class="text-uppercase fw-bold">Kontakt</h6>
+        <p class="small text-muted mb-1">📞 +420 123 456 789</p>
+        <p class="small text-muted mb-1">✉️ info@example.com</p>
+        <p class="small text-muted mt-3">© 2025 Rekonstrukce Praha</p>
+      </div>
+    </div>
+  </div>
+</footer>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ The site is ready to be served via GitHub Pages. Push the contents of this
 repository to a GitHub repository and enable Pages in the settings. The
 included `CNAME` file shows the custom domain that was used originally; adjust
 or remove it if you wish to use a different domain.
+GitHub Pages automatically serves `404.html` for any unknown route, so a custom
+error page will be displayed when a visitor enters a non-existent URL.


### PR DESCRIPTION
## Summary
- create `404.html` with same hero and footer styling as index
- update README to mention GitHub Pages automatic 404 handling

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68581a5e2b848322933ae90de2b97dcb