### PR TITLE
Add service icon strips

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -346,3 +346,8 @@ body.fasady .step {
 }
 .whatsapp-float:hover{background:#1ebe5d;}
 
+
+/* service icon strip */
+.services-strip i {color:#0d6efd;}
+.services-strip a:hover i {opacity:.8;transform:scale(.95);}
+.services-strip span {font-weight:500;}

--- a/index.html
+++ b/index.html
@@ -284,6 +284,49 @@
       </div>
     </div>
   </div>
+<!-- SERVICE ICON STRIP -->
+<section class="services-strip py-5 border-top bg-light">
+  <div class="container">
+    <div class="row g-3 text-center justify-content-center">
+      <div class="col-6 col-md">
+        <a href="/rekonstrukce-bytu-praha/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-building fs-2 mb-1"></i>
+          <span class="small d-block">Byty</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/rekonstrukce-domu-praha/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-house fs-2 mb-1"></i>
+          <span class="small d-block">Domy</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/koupelny/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-bucket fs-2 mb-1"></i>
+          <span class="small d-block">Koupelny</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/kuchyne/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-cup-hot fs-2 mb-1"></i>
+          <span class="small d-block">Kuchyně</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/zatepleni-fasad/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-bricks fs-2 mb-1"></i>
+          <span class="small d-block">Fasády</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/elektro-voda/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-lightning-charge fs-2 mb-1"></i>
+          <span class="small d-block">Elektro</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
 </footer>
 
 

--- a/sluzby.html
+++ b/sluzby.html
@@ -150,6 +150,49 @@
       </div>
     </div>
   </div>
+<!-- SERVICE ICON STRIP -->
+<section class="services-strip py-5 border-top bg-light">
+  <div class="container">
+    <div class="row g-3 text-center justify-content-center">
+      <div class="col-6 col-md">
+        <a href="/rekonstrukce-bytu-praha/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-building fs-2 mb-1"></i>
+          <span class="small d-block">Byty</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/rekonstrukce-domu-praha/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-house fs-2 mb-1"></i>
+          <span class="small d-block">Domy</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/koupelny/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-bucket fs-2 mb-1"></i>
+          <span class="small d-block">Koupelny</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/kuchyne/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-cup-hot fs-2 mb-1"></i>
+          <span class="small d-block">Kuchyně</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/zatepleni-fasad/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-bricks fs-2 mb-1"></i>
+          <span class="small d-block">Fasády</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="/elektro-voda/" class="d-block text-decoration-none text-dark">
+          <i class="bi bi-lightning-charge fs-2 mb-1"></i>
+          <span class="small d-block">Elektro</span>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
 </footer>
 
 


### PR DESCRIPTION
## Summary
- add service icon strip before the footer on the homepage and services page
- style service icon strip

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686a74deea488322a88dc9708b951610