### PR TITLE
Add services icons strip

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -346,3 +346,7 @@ body.fasady .step {
 }
 .whatsapp-float:hover{background:#1ebe5d;}
 
+.service-icon i        {color:#0d6efd; transition:transform .2s,opacity .2s;}
+.service-icon:hover i  {transform:translateY(-2px); opacity:.85;}
+.service-icon span     {font-weight:500; color:#212529;}
+

--- a/index.html
+++ b/index.html
@@ -248,6 +248,63 @@
   </div>
 </div>
 
+<section class="services-strip py-5 border-top bg-white">
+  <div class="container">
+    <div class="row g-4 justify-content-center text-center">
+
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-cup-hot fs-2"></i>
+          <span class="small d-block mt-1">Kitchen</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-bucket fs-2"></i>
+          <span class="small d-block mt-1">Bathroom</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-house-add fs-2"></i>
+          <span class="small d-block mt-1">Addition</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-sofa fs-2"></i>
+          <span class="small d-block mt-1">Living Space</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-house fs-2"></i>
+          <span class="small d-block mt-1">Attic</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-building-down fs-2"></i>
+          <span class="small d-block mt-1">Basement</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-bed fs-2"></i>
+          <span class="small d-block mt-1">Bedroom</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-plus-lg fs-2"></i>
+          <span class="small d-block mt-1">Other spaces</span>
+        </a>
+      </div>
+
+    </div>
+  </div>
+</section>
+
 <footer class="footer bg-dark text-light py-5 mt-5 border-top">
   <div class="container">
     <div class="row">

--- a/sluzby.html
+++ b/sluzby.html
@@ -114,6 +114,63 @@
   </div>
   </div>
 
+<section class="services-strip py-5 border-top bg-white">
+  <div class="container">
+    <div class="row g-4 justify-content-center text-center">
+
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-cup-hot fs-2"></i>
+          <span class="small d-block mt-1">Kitchen</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-bucket fs-2"></i>
+          <span class="small d-block mt-1">Bathroom</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-house-add fs-2"></i>
+          <span class="small d-block mt-1">Addition</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-sofa fs-2"></i>
+          <span class="small d-block mt-1">Living Space</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-house fs-2"></i>
+          <span class="small d-block mt-1">Attic</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-building-down fs-2"></i>
+          <span class="small d-block mt-1">Basement</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-bed fs-2"></i>
+          <span class="small d-block mt-1">Bedroom</span>
+        </a>
+      </div>
+      <div class="col-6 col-md">
+        <a href="#" class="service-icon d-block text-decoration-none">
+          <i class="bi bi-plus-lg fs-2"></i>
+          <span class="small d-block mt-1">Other spaces</span>
+        </a>
+      </div>
+
+    </div>
+  </div>
+</section>
+
 <footer class="footer bg-dark text-light py-5 mt-5 border-top">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
## Summary
- insert services strip before the footer on the home page and services page
- style hover effects for the service icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a76d04580832298e33af6dc926180