### PR TITLE
Update services strip layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -350,3 +350,6 @@ body.fasady .step {
 .service-icon:hover i  {transform:translateY(-2px); opacity:.85;}
 .service-icon span     {font-weight:500; color:#212529;}
 
+.service-card{background:#fff;border:1px solid #e7e7e7;border-radius:1rem;transition:transform .2s,box-shadow .2s;}
+.service-card:hover{transform:translateY(-4px);box-shadow:0 6px 18px rgba(0,0,0,.06);}
+.service-card i{color:#0d6efd;}

--- a/index.html
+++ b/index.html
@@ -248,63 +248,80 @@
   </div>
 </div>
 
-<section class="services-strip py-5 border-top bg-white">
-  <div class="container">
-    <div class="row g-4 justify-content-center text-center">
 
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-cup-hot fs-2"></i>
-          <span class="small d-block mt-1">Kitchen</span>
+
+<section class="services-strip py-5 border-top bg-light">
+  <div class="container text-center">
+    <h2 class="h4 mb-5">Na jakýkoli projekt se můžeme pustit již dnes</h2>
+
+    <div class="row gy-4 justify-content-center">
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-cup-hot fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Kitchen</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-bucket fs-2"></i>
-          <span class="small d-block mt-1">Bathroom</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-droplet fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Bathroom</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-house-add fs-2"></i>
-          <span class="small d-block mt-1">Addition</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-house-add fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Addition</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-sofa fs-2"></i>
-          <span class="small d-block mt-1">Living Space</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-sofa fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Living Space</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-house fs-2"></i>
-          <span class="small d-block mt-1">Attic</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-house fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Attic</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-building-down fs-2"></i>
-          <span class="small d-block mt-1">Basement</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-building-down fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Basement</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-bed fs-2"></i>
-          <span class="small d-block mt-1">Bedroom</span>
-        </a>
-      </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-plus-lg fs-2"></i>
-          <span class="small d-block mt-1">Other spaces</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-bed fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Bedroom</p>
+          </div>
         </a>
       </div>
 
     </div>
   </div>
 </section>
-
 <footer class="footer bg-dark text-light py-5 mt-5 border-top">
   <div class="container">
     <div class="row">

--- a/sluzby.html
+++ b/sluzby.html
@@ -114,63 +114,79 @@
   </div>
   </div>
 
-<section class="services-strip py-5 border-top bg-white">
-  <div class="container">
-    <div class="row g-4 justify-content-center text-center">
 
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-cup-hot fs-2"></i>
-          <span class="small d-block mt-1">Kitchen</span>
+<section class="services-strip py-5 border-top bg-light">
+  <div class="container text-center">
+    <h2 class="h4 mb-5">Na jakýkoli projekt se můžeme pustit již dnes</h2>
+
+    <div class="row gy-4 justify-content-center">
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-cup-hot fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Kitchen</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-bucket fs-2"></i>
-          <span class="small d-block mt-1">Bathroom</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-droplet fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Bathroom</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-house-add fs-2"></i>
-          <span class="small d-block mt-1">Addition</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-house-add fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Addition</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-sofa fs-2"></i>
-          <span class="small d-block mt-1">Living Space</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-sofa fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Living Space</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-house fs-2"></i>
-          <span class="small d-block mt-1">Attic</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-house fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Attic</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-building-down fs-2"></i>
-          <span class="small d-block mt-1">Basement</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-building-down fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Basement</p>
+          </div>
         </a>
       </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-bed fs-2"></i>
-          <span class="small d-block mt-1">Bedroom</span>
-        </a>
-      </div>
-      <div class="col-6 col-md">
-        <a href="#" class="service-icon d-block text-decoration-none">
-          <i class="bi bi-plus-lg fs-2"></i>
-          <span class="small d-block mt-1">Other spaces</span>
+
+      <div class="col-6 col-md-3 col-lg-2">
+        <a href="#" class="card service-card text-decoration-none h-100">
+          <div class="card-body">
+            <i class="bi bi-bed fs-1 mb-3"></i>
+            <p class="fw-medium mb-0">Bedroom</p>
+          </div>
         </a>
       </div>
 
     </div>
   </div>
 </section>
-
 <footer class="footer bg-dark text-light py-5 mt-5 border-top">
   <div class="container">
     <div class="row">


### PR DESCRIPTION
## Summary
- replace services strip section with seven icon cards on index and services pages
- remove `Other spaces` card
- style `.service-card` globally

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a82435d2483228fc022463a2798c0