### PR TITLE
Update Remix Icon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Kompletní rekonstrukce bytů a rodinných domů v Praze. Fixní cena, pevný termín, 5-letá záruka. Zdarma 3D návrh a denní fotoreport.">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="canonical" href="https://stavpraha.com/">
   <meta property="og:title" content="Rekonstrukce Praha">

--- a/sluzby.html
+++ b/sluzby.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Kompletní rekonstrukce bytů a rodinných domů v Praze. Fixní cena, pevný termín, 5-letá záruka. Zdarma 3D návrh a denní fotoreport.">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
-  <link href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css">
   <link rel="canonical" href="https://stavpraha.com/">
   <meta property="og:title" content="Rekonstrukce Praha">


### PR DESCRIPTION
## Summary
- bump Remix Icon CSS to version 4.2.0 in both templates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a9119a990832286a1fae2b6c758b8