### PR TITLE
Add placeholder images for mini-portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,24 +84,24 @@
       <!-- BYT -->
       <div class="col-md-4">
         <a href="#" class="d-block text-decoration-none">
-          <img src="/assets/img/portfolio/byt-before.jpg" alt="Byt před" class="w-100 mb-2">
-          <img src="/assets/img/portfolio/byt-after.jpg"  alt="Byt po"    class="w-100">
+          <img src="https://images.unsplash.com/photo-1570129477492-45c003edd2be?auto=format&fit=crop&w=600&q=80" alt="Byt před" class="w-100 mb-2">
+          <img src="https://images.unsplash.com/photo-1507089947368-19c1da9775ae?auto=format&fit=crop&w=600&q=80"  alt="Byt po"    class="w-100">
           <p class="small mt-2 mb-0 text-muted">Byt 2+kk · 45 m² · 4 týdny</p>
         </a>
       </div>
       <!-- DŮM -->
       <div class="col-md-4">
         <a href="#" class="d-block text-decoration-none">
-          <img src="/assets/img/portfolio/dum-before.jpg" alt="Dům před" class="w-100 mb-2">
-          <img src="/assets/img/portfolio/dum-after.jpg"  alt="Dům po"   class="w-100">
+          <img src="https://images.unsplash.com/photo-1595526114035-94f51ff9e25f?auto=format&fit=crop&w=600&q=80" alt="Dům před" class="w-100 mb-2">
+          <img src="https://images.unsplash.com/photo-1600585154154-75a5b482c0d0?auto=format&fit=crop&w=600&q=80"  alt="Dům po"   class="w-100">
           <p class="small mt-2 mb-0 text-muted">Dům 120 m² · 10 týdnů</p>
         </a>
       </div>
       <!-- KOUPELNA -->
       <div class="col-md-4">
         <a href="#" class="d-block text-decoration-none">
-          <img src="/assets/img/portfolio/bath-before.jpg" alt="Koupelna před" class="w-100 mb-2">
-          <img src="/assets/img/portfolio/bath-after.jpg"  alt="Koupelna po"   class="w-100">
+          <img src="https://images.unsplash.com/photo-1523217582562-09d0def993a6?auto=format&fit=crop&w=600&q=80" alt="Koupelna před" class="w-100 mb-2">
+          <img src="https://images.unsplash.com/photo-1600526605803-5a8205f5b0f6?auto=format&fit=crop&w=600&q=80"  alt="Koupelna po"   class="w-100">
           <p class="small mt-2 mb-0 text-muted">Koupelna · 10 dní</p>
         </a>
       </div>


### PR DESCRIPTION
## Summary
- replace broken image links in the "Ukázky realizací" section with placeholder Unsplash images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686aa1dcbe9c8322a68aabbf0995bfcb