### PR TITLE
Adjust partner logo sizes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -378,3 +378,7 @@ body.fasady .step {
   margin-inline:auto;
 }
 .partner-logo:hover{opacity:1;}
+
+.partner-logo.shrink{
+  max-height:55px;   /* чуть меньше основного 70px */
+}

--- a/index.html
+++ b/index.html
@@ -258,11 +258,11 @@
         <img src="/assets/img/partners/3.png" alt="Partner 3" class="partner-logo">
       </div>
       <div class="col-6 col-md-3 col-lg-3">
-        <img src="/assets/img/partners/4.png" alt="Partner 4" class="partner-logo">
+        <img src="/assets/img/partners/4.png" alt="Home Outlet" class="partner-logo shrink">
       </div>
 
       <div class="col-6 col-md-3 col-lg-3">
-        <img src="/assets/img/partners/5.png" alt="Partner 5" class="partner-logo">
+        <img src="/assets/img/partners/5.png" alt="MojePodlaha.cz" class="partner-logo shrink">
       </div>
       <div class="col-6 col-md-3 col-lg-3">
         <img src="/assets/img/partners/6.png" alt="Partner 6" class="partner-logo">


### PR DESCRIPTION
## Summary
- add `.partner-logo.shrink` CSS class for smaller logos
- update Home Outlet and MojePodlaha.cz images to use the new `shrink` class

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_6872474e8fcc83229e44a6331d41279b