### PR TITLE
Fix partners section title and image size

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -389,6 +389,7 @@ body.fasady .step {
 }
 .partner-box img{
   max-width:100%;
+  max-width:120px;
   max-height:100%;
   object-fit:contain;
   opacity:.85;

--- a/index.html
+++ b/index.html
@@ -244,6 +244,7 @@
 
 <section id="partners" class="py-5 bg-white border-top">
   <div class="container text-center">
+    <h2 class="h4 mb-3">Naši partneři</h2>
     <p class="text-muted mb-5">
       Díky partnerským cenám těchto značek získáte prvotřídní materiály za&nbsp;výhodnější cenu.
     </p>


### PR DESCRIPTION
## Summary
- restore partners heading on homepage
- constrain partner logo width for consistent scaling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687253d706ec832289dcfacdfad101d5