### PR TITLE
Add new site version under /v2/ with homepage banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,20 @@
 <link rel="manifest" href="/site.webmanifest">
 </head>
 <body class="home">
+<a href="/v2/" class="new-version-banner" aria-label="Přejít na novou verzi webu">
+  <span class="new-version-badge">NOVÉ</span>
+  <span class="new-version-text">Vyzkoušejte naši novou verzi webu</span>
+  <span class="new-version-arrow" aria-hidden="true">→</span>
+</a>
+<style>
+  .new-version-banner{display:flex;align-items:center;justify-content:center;gap:.6rem;padding:.65rem 1rem;background:linear-gradient(90deg,#0d6efd 0%,#0a58ca 100%);color:#fff;text-decoration:none;font-weight:500;font-size:.95rem;line-height:1.2;transition:filter .15s ease}
+  .new-version-banner:hover{filter:brightness(1.08);color:#fff;text-decoration:none}
+  .new-version-badge{background:#ffc107;color:#222;font-weight:700;font-size:.72rem;padding:.15rem .5rem;border-radius:999px;letter-spacing:.04em}
+  .new-version-text{}
+  .new-version-arrow{font-weight:700;transition:transform .2s ease}
+  .new-version-banner:hover .new-version-arrow{transform:translateX(4px)}
+  @media (max-width:480px){.new-version-banner{font-size:.85rem;padding:.55rem .75rem;gap:.45rem}}
+</style>
 <nav class="navbar navbar-expand-lg navbar-light bg-white shadow-sm">
   <div class="container">
     <a class="navbar-brand fw-bold d-flex align-items-center" href="/"><img src="/assets/img/branding/logo.png" alt="StavPraha logo" height="40" class="me-2"><span data-company-name>StavPraha</span></a>

--- a/v2/app.jsx
+++ b/v2/app.jsx
@@ -1,0 +1,117 @@
+// Main app
+const { useState: uS, useEffect: uE } = React;
+
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "theme": "light",
+  "accent": "#c8553d",
+  "headingFont": "Inter",
+  "density": 1
+}/*EDITMODE-END*/;
+
+const ACCENT_OPTIONS = [
+  '#c8553d', // terracotta (default)
+  '#1f5af0', // electric blue
+  '#16a34a', // green
+  '#eab308', // yellow
+];
+
+const FONT_OPTIONS = ['Inter', 'Space Grotesk', 'Fraunces', 'Instrument Serif'];
+
+function App() {
+  const [tweaks, setTweak] = window.useTweaks(TWEAK_DEFAULTS);
+
+  // Apply tweaks to root
+  uE(() => {
+    const root = document.documentElement;
+    root.setAttribute('data-theme', tweaks.theme);
+    root.style.setProperty('--accent', tweaks.accent);
+    root.style.setProperty('--accent-fg', tweaks.accent === '#eab308' ? '#0a0a0a' : '#ffffff');
+    root.style.setProperty('--density', tweaks.density);
+    if (tweaks.headingFont === 'Fraunces' || tweaks.headingFont === 'Instrument Serif') {
+      root.style.setProperty('--font-display', `'${tweaks.headingFont}', serif`);
+      root.style.setProperty('--display-weight', '600');
+      root.style.setProperty('--display-tracking', '-0.02em');
+    } else {
+      root.style.setProperty('--font-display', `'${tweaks.headingFont}', system-ui, sans-serif`);
+      root.style.setProperty('--display-weight', '700');
+      root.style.setProperty('--display-tracking', '-0.04em');
+    }
+  }, [tweaks]);
+
+  window.useReveal();
+  window.useParallax();
+
+  const {
+    TweaksPanel, TweakSection, TweakRadio, TweakColor, TweakSelect, TweakSlider,
+  } = window;
+
+  return (
+    <>
+      <window.ScrollProgress />
+      <window.CustomCursor />
+      <window.Nav />
+
+      <window.Hero />
+      <window.Marquee />
+      <window.About />
+      <window.Fears />
+      <window.Services />
+      <window.Portfolio />
+      <window.BeforeAfter />
+      <window.Process />
+      <window.Advantages />
+      <window.Calc />
+      <window.Spaces />
+      <window.Reviews />
+      <window.Certs />
+      <window.Team />
+      <window.Partners />
+      <window.Blog />
+      <window.Faq />
+      <window.Contact />
+      <window.Footer />
+
+      <a href={`https://wa.me/${window.SITE.whatsapp}`} className="wa-float" data-cursor="hover" aria-label="WhatsApp">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M17.6 6.32A7.85 7.85 0 0012.05 4a7.92 7.92 0 00-6.77 11.97L4 20l4.13-1.27a7.92 7.92 0 003.92 1h.01c4.36 0 7.92-3.55 7.92-7.91a7.86 7.86 0 00-2.38-5.5zM12.06 18.4h-.01a6.56 6.56 0 01-3.34-.92l-.24-.14-2.45.76.78-2.39-.16-.25a6.57 6.57 0 0110.2-8.13 6.51 6.51 0 011.93 4.64c0 3.62-2.95 6.57-6.57 6.57zm3.6-4.92c-.2-.1-1.17-.58-1.35-.64-.18-.07-.31-.1-.44.1-.13.2-.5.64-.62.77-.11.13-.23.15-.43.05-.2-.1-.83-.31-1.59-.98a5.99 5.99 0 01-1.1-1.37c-.12-.2-.01-.31.09-.41.09-.09.2-.23.3-.35.1-.12.13-.2.2-.33.06-.13.03-.25-.02-.35-.05-.1-.44-1.06-.6-1.46-.16-.38-.32-.33-.44-.34h-.38c-.13 0-.34.05-.52.25-.18.2-.69.67-.69 1.64 0 .96.7 1.9.8 2.02.1.13 1.4 2.13 3.38 2.99.47.2.84.32 1.13.41.47.15.9.13 1.24.08.38-.06 1.17-.48 1.34-.94.16-.46.16-.86.11-.94-.05-.08-.18-.13-.38-.23z"/>
+        </svg>
+      </a>
+
+      <TweaksPanel title="Tweaks">
+        <TweakSection label="Téma" />
+        <TweakRadio
+          label="Mode"
+          options={['light', 'dark']}
+          value={tweaks.theme}
+          onChange={(v) => setTweak('theme', v)}
+        />
+        <TweakSection label="Akcentní barva" />
+        <TweakColor
+          label="Accent"
+          options={ACCENT_OPTIONS}
+          value={tweaks.accent}
+          onChange={(v) => setTweak('accent', v)}
+        />
+        <TweakSection label="Typografie" />
+        <TweakSelect
+          label="Font nadpisů"
+          options={FONT_OPTIONS}
+          value={tweaks.headingFont}
+          onChange={(v) => setTweak('headingFont', v)}
+        />
+        <TweakSection label="Hustota" />
+        <TweakSlider
+          label="Density"
+          min={0.7}
+          max={1.4}
+          step={0.05}
+          value={tweaks.density}
+          onChange={(v) => setTweak('density', v)}
+        />
+      </TweaksPanel>
+    </>
+  );
+}
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/v2/cursor.jsx
+++ b/v2/cursor.jsx
@@ -1,0 +1,156 @@
+// Custom cursor + scroll progress
+const { useState, useEffect, useRef } = React;
+
+function CustomCursor() {
+  const dotRef = useRef(null);
+  const trailRef = useRef(null);
+  const stateRef = useRef({
+    x: 0, y: 0, tx: 0, ty: 0,
+    targetX: 0, targetY: 0,
+  });
+  const [hoverMode, setHoverMode] = useState(null);
+  const [label, setLabel] = useState('');
+
+  useEffect(() => {
+    const handleMove = (e) => {
+      stateRef.current.targetX = e.clientX;
+      stateRef.current.targetY = e.clientY;
+      if (dotRef.current) {
+        dotRef.current.style.left = e.clientX + 'px';
+        dotRef.current.style.top = e.clientY + 'px';
+      }
+    };
+    window.addEventListener('mousemove', handleMove);
+
+    let rafId;
+    const animate = () => {
+      const s = stateRef.current;
+      s.tx += (s.targetX - s.tx) * 0.15;
+      s.ty += (s.targetY - s.ty) * 0.15;
+      if (trailRef.current) {
+        trailRef.current.style.left = s.tx + 'px';
+        trailRef.current.style.top = s.ty + 'px';
+      }
+      rafId = requestAnimationFrame(animate);
+    };
+    animate();
+
+    // Delegated hover detection
+    const handleOver = (e) => {
+      const t = e.target.closest('[data-cursor]');
+      if (t) {
+        const mode = t.dataset.cursor;
+        setHoverMode(mode);
+        setLabel(t.dataset.cursorLabel || '');
+      } else if (e.target.closest('a, button, .btn, .nav-cta, [role="button"]')) {
+        setHoverMode('hover');
+        setLabel('');
+      } else {
+        setHoverMode(null);
+        setLabel('');
+      }
+    };
+    document.addEventListener('mouseover', handleOver);
+
+    return () => {
+      window.removeEventListener('mousemove', handleMove);
+      document.removeEventListener('mouseover', handleOver);
+      cancelAnimationFrame(rafId);
+    };
+  }, []);
+
+  let cls = 'cursor';
+  if (hoverMode === 'hover') cls += ' is-hover';
+  if (hoverMode === 'accent') cls += ' is-hover-accent';
+  if (hoverMode === 'text') cls += ' is-text';
+
+  return (
+    <>
+      <div ref={dotRef} className={cls}>
+        {label && <span className="cursor-label">{label}</span>}
+      </div>
+      <div ref={trailRef} className="cursor-trail"></div>
+    </>
+  );
+}
+
+function ScrollProgress() {
+  const ref = useRef(null);
+  useEffect(() => {
+    const update = () => {
+      const scrolled = window.scrollY;
+      const max = document.documentElement.scrollHeight - window.innerHeight;
+      const pct = max > 0 ? (scrolled / max) * 100 : 0;
+      if (ref.current) ref.current.style.width = pct + '%';
+    };
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+  return <div ref={ref} className="scroll-progress"></div>;
+}
+
+// Reveal — sets data-hidden initially then removes on intersect.
+// Uses data-attribute (not className) to avoid React reconciliation wiping it.
+function useReveal() {
+  useEffect(() => {
+    const els = Array.from(document.querySelectorAll('.reveal, .reveal-letters'));
+    // Tag everything as hidden first
+    els.forEach(el => el.setAttribute('data-hidden', '1'));
+    const reveal = (el) => {
+      el.removeAttribute('data-hidden');
+      el.classList.add('is-visible');
+    };
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) reveal(entry.target);
+      });
+    }, { threshold: 0.01, rootMargin: '0px 0px 100px 0px' });
+    els.forEach(el => observer.observe(el));
+    const checkInView = () => {
+      els.forEach(el => {
+        if (!el.hasAttribute('data-hidden')) return;
+        const r = el.getBoundingClientRect();
+        if (r.top < window.innerHeight + 100 && r.bottom > -100) reveal(el);
+      });
+    };
+    // Defer initial check so paint commits the hidden state first
+    requestAnimationFrame(() => requestAnimationFrame(checkInView));
+    setTimeout(checkInView, 300);
+    // Last-resort safety: anything still hidden after 2s, show it
+    setTimeout(() => {
+      els.forEach(el => el.hasAttribute('data-hidden') && reveal(el));
+    }, 2000);
+    return () => observer.disconnect();
+  }, []);
+}
+
+// Parallax hook — moves any [data-parallax="0.2"] elem on scroll
+function useParallax() {
+  useEffect(() => {
+    const els = Array.from(document.querySelectorAll('[data-parallax]'));
+    const update = () => {
+      const vh = window.innerHeight;
+      els.forEach(el => {
+        const rect = el.getBoundingClientRect();
+        const speed = parseFloat(el.dataset.parallax) || 0.2;
+        const center = rect.top + rect.height / 2 - vh / 2;
+        const offset = -center * speed;
+        el.style.transform = `translate3d(0, ${offset}px, 0)`;
+      });
+    };
+    update();
+    window.addEventListener('scroll', update, { passive: true });
+    window.addEventListener('resize', update);
+    return () => {
+      window.removeEventListener('scroll', update);
+      window.removeEventListener('resize', update);
+    };
+  }, []);
+}
+
+Object.assign(window, { CustomCursor, ScrollProgress, useReveal, useParallax });

--- a/v2/data.jsx
+++ b/v2/data.jsx
@@ -1,0 +1,121 @@
+// Data extracted from stavpraha.com (DanDirector/praha repo)
+
+const SITE = {
+  companyName: 'StavPraha',
+  tagline: 'Stavební a rekonstrukční práce pro byty, domy a komerční prostory',
+  primaryCity: 'Praha',
+  location: 'Praha a okolí',
+  phone: '+420 777 000 000',
+  email: 'info@stavpraha.com',
+  whatsapp: '420777000000',
+  ico: '00000000',
+  address: 'Praha a okolí',
+  warrantyText: 'Záruka dle typu prací a smlouvy',
+};
+
+const SERVICES = [
+  { slug: 'rekonstrukce-bytu', name: 'Rekonstrukce bytu', desc: 'Kompletní i částečné úpravy bytů od přípravy po předání.', tags: ['Byty', 'Na klíč'], img: 'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'rekonstrukce-koupelny', name: 'Rekonstrukce koupelny', desc: 'Nové rozvody, obklady, sanita a dokončovací práce na klíč.', tags: ['Koupelny', 'WC'], img: 'https://images.unsplash.com/photo-1552321554-5fefe8c9ef14?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'obkladacske-prace', name: 'Obkladačské práce', desc: 'Pokládka obkladů a dlažby pro koupelny, kuchyně i podlahy.', tags: ['Dlažba', 'Obklady'], img: 'https://images.unsplash.com/photo-1631679706909-1844bbd07221?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'elektroinstalace', name: 'Elektroinstalace', desc: 'Úpravy rozvodů, zásuvek, osvětlení a revize podle typu zakázky.', tags: ['Elektro', 'Revize'], img: 'https://images.unsplash.com/photo-1558618666-fcd25c85cd64?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'hodinovy-manzel', name: 'Hodinový manžel', desc: 'Drobné opravy, montáže a údržba domácnosti podle domluvy.', tags: ['Opravy', 'Montáž'], img: 'https://images.unsplash.com/photo-1581578731548-c64695cc6952?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'rekonstrukce-kancelari', name: 'Rekonstrukce kanceláří', desc: 'Úpravy kanceláří a komerčních prostor s jasným harmonogramem.', tags: ['Office', 'B2B'], img: 'https://images.unsplash.com/photo-1497366754035-f200968a6e72?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'kosmeticky-remont', name: 'Kosmetické opravy', desc: 'Drobné opravy povrchů, malování a dokončovací práce.', tags: ['Malování'], img: 'https://images.unsplash.com/photo-1562259949-e8e7689d7828?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'zatepleni-fasady', name: 'Zateplení fasád', desc: 'Zateplení a fasádní práce podle stavu domu a zvoleného systému.', tags: ['Fasády', 'Tepelná izolace'], img: 'https://images.unsplash.com/photo-1503387762-592deb58ef4e?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'stukovani-omitky', name: 'Štukatérské práce', desc: 'Omítky, štukování a příprava stěn pro malování nebo obklady.', tags: ['Omítky', 'Štuk'], img: 'https://images.unsplash.com/photo-1503594384566-461fe158e797?auto=format&fit=crop&w=900&q=80' },
+  { slug: 'rekonstrukce-domu', name: 'Rekonstrukce domů', desc: 'Úpravy rodinných domů, interiérů i navazujících stavebních prací.', tags: ['RD', 'Komplet'], img: 'https://images.unsplash.com/photo-1564540583246-934409427776?auto=format&fit=crop&w=900&q=80' },
+];
+
+const FEARS = [
+  { text: 'Že se cena během prací nečekaně navýší', meta: 'Fixní rozsah' },
+  { text: 'Že nebude jasné, kdo za zakázku odpovídá', meta: 'Jeden kontakt' },
+  { text: 'Že se práce protáhnou bez vysvětlení', meta: 'Harmonogram' },
+  { text: 'Že po řemeslnících zůstane nepořádek', meta: 'Úklid v ceně' },
+  { text: 'Že nebude jasné, co je a není v ceně', meta: 'Rozpočet předem' },
+];
+
+const ADVANTAGES = [
+  { title: 'Přehledný rozpočet před začátkem prací', text: 'Rozsah prací, materiál a termín domlouváme předem, aby bylo jasné, co je součástí zakázky.' },
+  { title: 'Možnost návrhu podle rozsahu zakázky', text: 'Podle typu prací pomůžeme upřesnit dispozici, materiály a výsledný vzhled ještě před zahájením realizace.' },
+  { title: 'Orientační odhad ceny online', text: 'Zadejte pár údajů a získáte první orientační rozpočet, který můžeme následně upřesnit podle reálného rozsahu.' },
+  { title: 'Záruka dle typu prací a smlouvy', text: 'Záruční podmínky a odpovědnost za provedené práce nastavujeme podle konkrétní zakázky a použitých materiálů.' },
+  { title: 'Materiály podle dohody a rozpočtu', text: 'Materiály vybíráme podle rozsahu prací, požadované kvality a domluveného rozpočtu.' },
+  { title: 'Ukázky prací podle typu zakázky', text: 'Při domluvě pomohou fotografie, reference a ukázky podobných realizací podle rozsahu plánovaných prací.' },
+];
+
+const PROCESS = [
+  { title: 'Pošlete popis nebo fotky', text: 'Stačí základní informace o prostoru, lokalitě a tom, co chcete změnit.' },
+  { title: 'Upřesníme rozsah a možnosti', text: 'Projdeme návaznosti, materiál, termín podle dostupnosti a možná omezení.' },
+  { title: 'Domluvíme zaměření', text: 'U větších zakázek ověříme stav prostoru, rozvodů, podkladu a přístupu.' },
+  { title: 'Připravíme rozpočet a postup', text: 'Rozsah prací domluvíme předem, aby bylo jasné, co je a není součástí.' },
+  { title: 'Realizace a průběžná komunikace', text: 'Během prací držíme jeden kontakt a podle potřeby posíláme průběžné informace.' },
+  { title: 'Úklid, kontrola a předání', text: 'Zakázku uzavírá kontrola provedených prací a předání hotového prostoru.' },
+];
+
+const REVIEWS = [
+  { text: 'Férovou domluvu před začátkem prací a jasnější představu o ceně a rozsahu.', name: 'Martin', stage: 'Před zahájením', img: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&w=200&q=80' },
+  { text: 'Průběžnou komunikaci během realizace a jeden kontakt pro domluvu.', name: 'Lucie', stage: 'Během prací', img: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?auto=format&fit=crop&w=200&q=80' },
+  { text: 'Čistší předání prostoru a srozumitelný další postup po dokončení.', name: 'Honza', stage: 'Předání', img: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=200&q=80' },
+];
+
+const SPACES = [
+  { name: 'Kuchyně', glyph: '◐' },
+  { name: 'Koupelna', glyph: '◇' },
+  { name: 'Přístavba', glyph: '◑' },
+  { name: 'Obytný prostor', glyph: '◧' },
+  { name: 'Podkroví', glyph: '◮' },
+  { name: 'Sklep', glyph: '◨' },
+  { name: 'Ložnice', glyph: '◍' },
+];
+
+const PARTNERS = [
+  'KNAUF', 'CEMIX', 'BAUMIT', 'HORNBACH', 'RAKO', 'SIKO', 'JIKA', 'WEBER',
+];
+
+const CERTS = [
+  { name: 'Živnostenské oprávnění', code: 'ŽL', meta: 'Stavební činnost' },
+  { name: 'Pojištění odpovědnosti', code: 'INS', meta: 'Profesní pojištění' },
+  { name: 'Členství v cechu', code: 'CCH', meta: 'Cech malířů a lakýrníků' },
+  { name: 'Energetický auditor', code: 'EA', meta: 'Zateplení fasád' },
+];
+
+const TEAM = [
+  { name: 'Daniel', role: 'Zakladatel · Vedení zakázek', img: 'https://images.unsplash.com/photo-1560250097-0b93528c311a?auto=format&fit=crop&w=600&q=80' },
+  { name: 'Tomáš', role: 'Stavbyvedoucí', img: 'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?auto=format&fit=crop&w=600&q=80' },
+  { name: 'Pavel', role: 'Obkladač · Štukatér', img: 'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?auto=format&fit=crop&w=600&q=80' },
+  { name: 'Jana', role: 'Koordinátor projektů', img: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?auto=format&fit=crop&w=600&q=80' },
+];
+
+const BLOG = [
+  { date: '12 / 05 / 26', cat: 'Rekonstrukce', title: 'Kolik stojí rekonstrukce panelového bytu v roce 2026' },
+  { date: '28 / 04 / 26', cat: 'Koupelna', title: 'Bytové jádro vs. zděná koupelna: srovnání nákladů' },
+  { date: '15 / 04 / 26', cat: 'Materiály', title: 'Velkoformátová dlažba — kdy se vyplatí a kdy ne' },
+  { date: '03 / 04 / 26', cat: 'Proces', title: 'Co musí být ve smlouvě o dílo: 7 bodů, na které lidé zapomínají' },
+  { date: '21 / 03 / 26', cat: 'Fasáda', title: 'Zateplení fasády bytového domu: na co se ptát realizátora' },
+];
+
+const FAQ = [
+  { q: 'Kolik stojí rekonstrukce bytu v Praze?', a: 'Orientačně může částečná rekonstrukce začínat od 3 500 Kč/m² a kompletní rekonstrukce od 8 000 Kč/m². Výsledná cena závisí na stavu bytu, rozsahu prací, materiálech a možnostech realizace.' },
+  { q: 'Jak dlouho rekonstrukce bytu trvá?', a: 'Termín závisí na rozsahu, stavu bytu, dostupnosti materiálů a návaznosti profesí. Menší úpravy mohou být kratší, kompletní rekonstrukce vyžaduje podrobnější harmonogram.' },
+  { q: 'Může být byt během rekonstrukce obývaný?', a: 'Záleží na rozsahu prací. U menších úprav to někdy možné je, u zásahů do koupelny, rozvodů, podlah nebo více místností bývá praktičtější byt dočasně vyklidit.' },
+  { q: 'Můžu dodat vlastní materiál?', a: 'Ano, materiál může dodat klient nebo jej lze vybrat společně podle rozpočtu a požadovaného výsledku. Vhodnost materiálu je dobré ověřit před zahájením prací.' },
+  { q: 'Řešíte i elektro, vodu a odpady?', a: 'Ano, podle rozsahu rekonstrukce lze řešit elektro, vodu a odpady. Revize a odborné úkony se řeší podle typu zakázky a požadavků.' },
+  { q: 'Dostanu smlouvu, fakturu a záruku?', a: 'Zakázku je vhodné řešit s jasným rozsahem prací, rozpočtem, fakturou a záručními podmínkami podle typu provedených prací a smlouvy.' },
+];
+
+const PORTFOLIO = [
+  { title: 'Byt 3+kk · Vinohrady', tag: 'Kompletní rekonstrukce', img: 'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?auto=format&fit=crop&w=1400&q=80' },
+  { title: 'Koupelna · Smíchov', tag: 'Na klíč', img: 'https://images.unsplash.com/photo-1552321554-5fefe8c9ef14?auto=format&fit=crop&w=1200&q=80' },
+  { title: 'Kancelář · Karlín', tag: 'Komerční prostor', img: 'https://images.unsplash.com/photo-1497366754035-f200968a6e72?auto=format&fit=crop&w=1200&q=80' },
+  { title: 'Rodinný dům · Praha-západ', tag: 'Interiér + fasáda', img: 'https://images.unsplash.com/photo-1564540583246-934409427776?auto=format&fit=crop&w=1400&q=80' },
+];
+
+const BEFORE_AFTER = {
+  before: 'https://images.unsplash.com/photo-1503594384566-461fe158e797?auto=format&fit=crop&w=1600&q=80',
+  after: 'https://images.unsplash.com/photo-1600585154340-be6161a56a0c?auto=format&fit=crop&w=1600&q=80',
+};
+
+Object.assign(window, {
+  SITE, SERVICES, FEARS, ADVANTAGES, PROCESS, REVIEWS, SPACES, PARTNERS,
+  CERTS, TEAM, BLOG, FAQ, PORTFOLIO, BEFORE_AFTER,
+});

--- a/v2/index.html
+++ b/v2/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>StavPraha — Rekonstrukce bytů, koupelen a domů v Praze</title>
+<meta name="description" content="Stavební a rekonstrukční práce v Praze a okolí. Přehledný rozpočet, jasný postup, jeden kontakt a realizace od zaměření po předání.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&family=Instrument+Serif:ital@0;1&family=Space+Grotesk:wght@400;500;600;700&family=Fraunces:ital,wght@0,400;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<div id="root"></div>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<script type="text/babel" src="tweaks-panel.jsx"></script>
+<script type="text/babel" src="data.jsx"></script>
+<script type="text/babel" src="cursor.jsx"></script>
+<script type="text/babel" src="sections.jsx"></script>
+<script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/v2/sections.jsx
+++ b/v2/sections.jsx
@@ -1,0 +1,674 @@
+// All page sections
+const { useState: useS, useEffect: useE, useRef: useR } = React;
+
+// ============================================
+// NAV
+// ============================================
+function Nav() {
+  return (
+    <nav className="nav">
+      <a href="#top" className="nav-logo" data-cursor="hover">
+        <span className="nav-logo-mark"></span>
+        <span>StavPraha</span>
+      </a>
+      <ul className="nav-links">
+        <li><a href="#sluzby">Služby</a></li>
+        <li><a href="#portfolio">Reference</a></li>
+        <li><a href="#proces">Proces</a></li>
+        <li><a href="#kalkulator">Kalkulačka</a></li>
+        <li><a href="#kontakt">Kontakt</a></li>
+      </ul>
+      <a href="#kontakt" className="nav-cta" data-cursor="hover">Nezávazná poptávka →</a>
+    </nav>
+  );
+}
+
+// ============================================
+// HERO
+// ============================================
+function Hero() {
+  return (
+    <section className="hero" id="top">
+      <div className="container" style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+        <div className="hero-meta">
+          <span>StavPraha · 2026</span>
+          <span>Praha a okolí · CZ</span>
+          <span>↓ Scroll</span>
+        </div>
+        <div className="hero-spacer"></div>
+        <h1 className="hero-title reveal">
+          Rekonstrukce<br />
+          bytů, koupelen<br />
+          a domů <em>v Praze</em><br />
+          bez chaosu.
+        </h1>
+        <div className="hero-strip"></div>
+        <div className="hero-bottom">
+          <p className="hero-sub reveal">
+            Přehledný rozpočet, jasný postup, jeden kontakt a realizace od zaměření po předání. Více než deset profesí pod jednou střechou — od bourání po úklid a předání hotového prostoru.
+          </p>
+          <div className="hero-ctas">
+            <a href="#kalkulator" className="btn btn-accent" data-cursor="accent" data-cursor-label="Spočítat">
+              Získat orientační kalkulaci
+              <span className="btn-arrow"></span>
+            </a>
+            <a href="#" className="btn btn-outline" data-cursor="hover">
+              WhatsApp
+              <span className="btn-arrow"></span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// MARQUEE
+// ============================================
+function Marquee() {
+  const items = ['Rekonstrukce', 'Koupelny', 'Elektroinstalace', 'Fasády', 'Štuky', 'Obklady', 'Kanceláře'];
+  return (
+    <div className="marquee">
+      <div className="marquee-track">
+        {[...items, ...items, ...items].map((it, i) => (
+          <span key={i} className="marquee-item">{it}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// ABOUT
+// ============================================
+function About() {
+  return (
+    <section id="o-nas">
+      <div className="container">
+        <div className="section-label mono reveal">[01] / O nás</div>
+        <div className="about-grid">
+          <div className="about-lead reveal">
+            Stavební a rekonstrukční práce <em>pro byty, domy a komerční prostory</em> v Praze a okolí. Pracujeme s předem domluveným rozsahem, orientačním rozpočtem a průběžnou komunikací.
+          </div>
+          <div className="about-side">
+            <div className="about-stat reveal">
+              <div className="about-stat-num">10<em>+</em></div>
+              <div className="about-stat-label">profesí pod jednou střechou — bourání, elektro, voda, obklady, štuky, podlahy, dveře, úklid</div>
+            </div>
+            <div className="about-stat reveal">
+              <div className="about-stat-num">1</div>
+              <div className="about-stat-label">kontakt po celou dobu zakázky — bez přeposílání mezi řemeslníky</div>
+            </div>
+            <div className="about-stat reveal">
+              <div className="about-stat-num"><em>0</em></div>
+              <div className="about-stat-label">skrytých položek v rozpočtu — co domluvíme, to platí</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// FEARS (concerns list)
+// ============================================
+function Fears() {
+  return (
+    <section id="obavy">
+      <div className="container">
+        <div className="section-label mono reveal">[02] / Obavy</div>
+        <h2 className="display medium reveal" style={{ marginBottom: 'var(--space-3)', maxWidth: '20ch' }}>
+          Čeho se lidé při rekonstrukci nejčastěji obávají?
+        </h2>
+        <div className="list-rows">
+          {window.FEARS.map((f, i) => (
+            <div key={i} className="list-row reveal" data-cursor="hover">
+              <div className="list-row-num">{String(i + 1).padStart(2, '0')}</div>
+              <div className="list-row-text">{f.text}</div>
+              <div className="list-row-meta">→ {f.meta}</div>
+            </div>
+          ))}
+        </div>
+        <p className="reveal" style={{ marginTop: 'var(--space-3)', fontSize: '20px', maxWidth: '60ch', color: 'var(--fg-muted)' }}>
+          Proto pracujeme s předem domluveným rozsahem, orientačním rozpočtem, průběžnou komunikací a předáním hotové práce.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// SERVICES
+// ============================================
+function Services() {
+  const [hover, setHover] = useS(null);
+  const [pos, setPos] = useS({ x: 0, y: 0 });
+  const wrapRef = useR(null);
+
+  useE(() => {
+    const move = (e) => setPos({ x: e.clientX + 24, y: e.clientY - 110 });
+    if (hover !== null) {
+      window.addEventListener('mousemove', move);
+      return () => window.removeEventListener('mousemove', move);
+    }
+  }, [hover]);
+
+  return (
+    <section id="sluzby" style={{ background: 'var(--bg-alt)' }}>
+      <div className="container">
+        <div className="section-label mono reveal">[03] / Služby</div>
+        <h2 className="display big reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Co děláme
+        </h2>
+        <div className="services-list" ref={wrapRef}>
+          {window.SERVICES.map((s, i) => (
+            <div
+              key={s.slug}
+              className="service-item reveal"
+              data-cursor="accent"
+              data-cursor-label="→ Více"
+              onMouseEnter={() => setHover(i)}
+              onMouseLeave={() => setHover(null)}
+            >
+              <div className="service-num">{String(i + 1).padStart(2, '0')}</div>
+              <div className="service-name">{s.name}</div>
+              <div className="service-desc">{s.desc}</div>
+              <div className="service-tags">
+                {s.tags.map(t => <span key={t} className="service-tag">{t}</span>)}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      {hover !== null && (
+        <div className={'service-preview active'} style={{ left: pos.x, top: pos.y }}>
+          <img src={window.SERVICES[hover].img} alt="" />
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ============================================
+// PORTFOLIO
+// ============================================
+function Portfolio() {
+  return (
+    <section id="portfolio">
+      <div className="container">
+        <div className="section-label mono reveal">[04] / Reference</div>
+        <h2 className="display big reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Realizované<br />projekty.
+        </h2>
+        <div className="portfolio-grid">
+          {window.PORTFOLIO.map((p, i) => (
+            <div key={i} className={`port-card port-${i + 1} reveal`} data-cursor="accent" data-cursor-label="View">
+              <img src={p.img} alt={p.title} />
+              <div className="port-card-meta">
+                <div className="port-card-title">{p.title}</div>
+                <div className="port-card-tag">{p.tag}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// BEFORE / AFTER
+// ============================================
+function BeforeAfter() {
+  const [pos, setPos] = useS(50);
+  const wrapRef = useR(null);
+
+  const onMove = (clientX) => {
+    if (!wrapRef.current) return;
+    const rect = wrapRef.current.getBoundingClientRect();
+    const x = ((clientX - rect.left) / rect.width) * 100;
+    setPos(Math.max(0, Math.min(100, x)));
+  };
+  const onMouseMove = (e) => onMove(e.clientX);
+  const onTouchMove = (e) => onMove(e.touches[0].clientX);
+
+  return (
+    <section>
+      <div className="container">
+        <div className="section-label mono reveal">[05] / Před a po</div>
+        <h2 className="display medium reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Jak může rekonstrukce<br />změnit váš byt.
+        </h2>
+        <div
+          className="ba-wrap reveal"
+          ref={wrapRef}
+          onMouseMove={onMouseMove}
+          onTouchMove={onTouchMove}
+          data-cursor="hover"
+        >
+          <img src={window.BEFORE_AFTER.before} alt="Před" />
+          <div className="ba-after-clip" style={{ clipPath: `inset(0 0 0 ${pos}%)` }}>
+            <img src={window.BEFORE_AFTER.after} alt="Po" />
+          </div>
+          <div className="ba-handle" style={{ left: `${pos}%` }}></div>
+          <div className="ba-label" style={{ left: 16 }}>Před</div>
+          <div className="ba-label" style={{ right: 16 }}>Po</div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// PROCESS
+// ============================================
+function Process() {
+  return (
+    <section id="proces" style={{ background: 'var(--bg-alt)' }}>
+      <div className="container">
+        <div className="section-label mono reveal">[06] / Proces</div>
+        <div className="process">
+          <div className="process-side reveal">
+            <h2>Jak<br />probíhá<br /><em>spolupráce.</em></h2>
+            <p style={{ marginTop: 'var(--space-2)', color: 'var(--fg-muted)', maxWidth: '34ch' }}>
+              Šest jasných kroků od první zprávy po předání hotového prostoru.
+            </p>
+          </div>
+          <div className="process-steps">
+            {window.PROCESS.map((p, i) => (
+              <div key={i} className="process-step reveal">
+                <div className="process-step-head">
+                  <span className="process-step-num">STEP / {String(i + 1).padStart(2, '0')}</span>
+                  <span className="mono" style={{ color: 'var(--fg-muted)' }}>{['1–2 dny','1–3 dny','2–5 dní','3–7 dní','týdny','1–2 dny'][i]}</span>
+                </div>
+                <h3 className="process-step-title">{p.title}</h3>
+                <p className="process-step-text">{p.text}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// ADVANTAGES
+// ============================================
+function Advantages() {
+  return (
+    <section id="vyhody">
+      <div className="container">
+        <div className="section-label mono reveal">[07] / Výhody</div>
+        <h2 className="display big reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Naše výhody.
+        </h2>
+        <div className="list-rows">
+          {window.ADVANTAGES.map((a, i) => (
+            <div key={i} className="list-row reveal" data-cursor="hover" style={{ gridTemplateColumns: '80px 1fr 1fr' }}>
+              <div className="list-row-num">{String(i + 1).padStart(2, '0')}</div>
+              <div className="list-row-text">{a.title}</div>
+              <div style={{ color: 'var(--fg-muted)', fontSize: 14, maxWidth: '46ch' }}>{a.text}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// CALCULATOR
+// ============================================
+function Calc() {
+  const [type, setType] = useS('flat');
+  const [area, setArea] = useS('');
+
+  const prices = { flat: 14000, house: 15500 };
+  const a = parseFloat(area);
+  const valid = !isNaN(a) && a >= 10;
+  const estimate = valid ? a * prices[type] : 0;
+
+  return (
+    <section id="kalkulator">
+      <div className="container">
+        <div className="section-label mono reveal">[08] / Kalkulačka</div>
+        <div className="calc reveal">
+          <div className="calc-grid">
+            <div className="calc-head">
+              <h2>Orientační<br /><em>cena</em><br />rekonstrukce.</h2>
+              <p>Výpočet slouží jen pro první orientaci. Finální cena závisí na konzultaci, zaměření a přesném rozsahu prací.</p>
+            </div>
+            <div className="calc-form">
+              <div className="calc-field">
+                <span className="calc-label">Typ objektu</span>
+                <div className="calc-select-row">
+                  <button className={`calc-chip ${type === 'flat' ? 'active' : ''}`} onClick={() => setType('flat')} data-cursor="hover">Byt</button>
+                  <button className={`calc-chip ${type === 'house' ? 'active' : ''}`} onClick={() => setType('house')} data-cursor="hover">Dům</button>
+                </div>
+              </div>
+              <div className="calc-field">
+                <span className="calc-label">Plocha (m²)</span>
+                <input
+                  className="calc-input"
+                  type="number"
+                  min="10"
+                  placeholder="0"
+                  value={area}
+                  onChange={(e) => setArea(e.target.value)}
+                  data-cursor="text"
+                />
+              </div>
+              <div className="calc-result">
+                <span className="calc-result-label">Orientační cena</span>
+                <div className="calc-result-value">
+                  {valid ? (
+                    <><em>{estimate.toLocaleString('cs-CZ')}</em> Kč</>
+                  ) : (
+                    <span style={{ opacity: 0.4 }}>— — — Kč</span>
+                  )}
+                </div>
+                <p className="calc-note">Sazba {prices[type].toLocaleString('cs-CZ')} Kč/m². Nejde o závaznou nabídku.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// SPACES
+// ============================================
+function Spaces() {
+  return (
+    <section id="prostory">
+      <div className="container">
+        <div className="section-label mono reveal">[09] / Prostory</div>
+        <h2 className="display medium reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Pro jaké prostory<br />se práce hodí.
+        </h2>
+        <div className="spaces-grid">
+          {window.SPACES.map((s, i) => (
+            <div key={i} className="space-chip reveal" data-cursor="hover">
+              <div className="space-glyph">{s.glyph}</div>
+              <div className="space-name">{s.name}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// REVIEWS
+// ============================================
+function Reviews() {
+  return (
+    <section id="reference" style={{ background: 'var(--bg-alt)' }}>
+      <div className="container">
+        <div className="section-label mono reveal">[10] / Reference</div>
+        <h2 className="display medium reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Co zákazníci<br /><em style={{ fontStyle: 'italic', color: 'var(--accent)' }}>obvykle oceňují</em>.
+        </h2>
+        <div className="reviews">
+          {window.REVIEWS.map((r, i) => (
+            <div key={i} className="review reveal">
+              <div className="review-quote-mark">"</div>
+              <div className="review-text">{r.text}</div>
+              <div className="review-author">
+                <div className="review-avatar"><img src={r.img} alt={r.name} /></div>
+                <div>
+                  <div className="review-author-name">{r.name}</div>
+                  <div className="review-author-stage">{r.stage}</div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// CERTIFICATES
+// ============================================
+function Certs() {
+  return (
+    <section id="certifikaty">
+      <div className="container">
+        <div className="section-label mono reveal">[11] / Certifikáty</div>
+        <h2 className="display medium reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Licence a<br />pojištění.
+        </h2>
+        <div className="certs-grid">
+          {window.CERTS.map((c, i) => (
+            <div key={i} className="cert reveal" data-cursor="hover">
+              <div className="cert-icon">{c.code}</div>
+              <div>
+                <div className="cert-name">{c.name}</div>
+                <div className="cert-meta">{c.meta}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// TEAM
+// ============================================
+function Team() {
+  return (
+    <section id="tym">
+      <div className="container">
+        <div className="section-label mono reveal">[12] / Tým</div>
+        <h2 className="display big reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Lidé za<br />zakázkou.
+        </h2>
+        <div className="team-grid">
+          {window.TEAM.map((t, i) => (
+            <div key={i} className="team-card reveal" data-cursor="hover">
+              <div className="team-photo"><img src={t.img} alt={t.name} /></div>
+              <div className="team-name">{t.name}</div>
+              <div className="team-role">{t.role}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// PARTNERS
+// ============================================
+function Partners() {
+  return (
+    <section id="partneri" style={{ background: 'var(--bg-alt)' }}>
+      <div className="container">
+        <div className="section-label mono reveal">[13] / Partneři</div>
+        <h2 className="display medium reveal" style={{ marginBottom: 'var(--space-3)' }}>
+          Materiály a značky.
+        </h2>
+        <p className="reveal" style={{ color: 'var(--fg-muted)', marginBottom: 'var(--space-3)', maxWidth: '60ch' }}>
+          Materiály a značky lze zvolit podle rozpočtu, dostupnosti a požadovaného výsledku.
+        </p>
+        <div className="partners reveal">
+          {window.PARTNERS.map((p, i) => (
+            <div key={i} className="partner-box"><span>{p}</span></div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// BLOG
+// ============================================
+function Blog() {
+  return (
+    <section id="blog">
+      <div className="container">
+        <div className="section-label mono reveal">[14] / Blog</div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', marginBottom: 'var(--space-3)', flexWrap: 'wrap', gap: 16 }}>
+          <h2 className="display big reveal">
+            Aktuálně<br />ze stavby.
+          </h2>
+          <a href="#" className="btn btn-outline" data-cursor="hover">Všechny články <span className="btn-arrow"></span></a>
+        </div>
+        <div className="blog-list">
+          {window.BLOG.map((b, i) => (
+            <div key={i} className="blog-item reveal" data-cursor="hover">
+              <div className="blog-date">{b.date}</div>
+              <div className="blog-cat">{b.cat}</div>
+              <div className="blog-title">{b.title}</div>
+              <div className="blog-arrow"><span className="btn-arrow"></span></div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// FAQ
+// ============================================
+function Faq() {
+  const [open, setOpen] = useS(0);
+  return (
+    <section id="faq" style={{ background: 'var(--bg-alt)' }}>
+      <div className="container">
+        <div className="section-label mono reveal">[15] / FAQ</div>
+        <div className="faq-grid">
+          <div className="reveal">
+            <h2 className="display medium">
+              Časté<br /><em style={{ fontStyle: 'italic', color: 'var(--accent)' }}>otázky.</em>
+            </h2>
+            <p style={{ marginTop: 'var(--space-2)', color: 'var(--fg-muted)', maxWidth: '40ch' }}>
+              Něco vám tu chybí? <a href="#kontakt" style={{ color: 'var(--fg)', textDecoration: 'underline' }}>Napište nám</a>.
+            </p>
+          </div>
+          <div className="faq-list">
+            {window.FAQ.map((f, i) => (
+              <div key={i} className={`faq-item ${open === i ? 'open' : ''}`} onClick={() => setOpen(open === i ? -1 : i)} data-cursor="hover">
+                <div className="faq-q">
+                  <div className="faq-q-text">{f.q}</div>
+                  <div className="faq-toggle">+</div>
+                </div>
+                <div className="faq-a">
+                  <div className="faq-a-inner">{f.a}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// CONTACT
+// ============================================
+function Contact() {
+  return (
+    <section id="kontakt">
+      <div className="container">
+        <div className="section-label mono reveal">[16] / Kontakt</div>
+        <h2 className="contact-hero reveal">
+          Pošlete<br />popis nebo <em>fotky.</em>
+        </h2>
+        <p className="reveal" style={{ fontSize: 'clamp(18px, 2vw, 24px)', maxWidth: '60ch', color: 'var(--fg-muted)', marginBottom: 'var(--space-3)' }}>
+          Podle základních informací vám řekneme, jaký postup dává smysl a co bude potřeba upřesnit. Ozveme se s dalším postupem nebo orientační kalkulací.
+        </p>
+        <div className="contact-grid">
+          <div className="contact-block reveal">
+            <span className="contact-label">Telefon</span>
+            <a href={`tel:${window.SITE.phone}`} className="contact-value" data-cursor="hover">{window.SITE.phone}</a>
+          </div>
+          <div className="contact-block reveal">
+            <span className="contact-label">E-mail</span>
+            <a href={`mailto:${window.SITE.email}`} className="contact-value" data-cursor="hover">{window.SITE.email}</a>
+          </div>
+          <div className="contact-block reveal">
+            <span className="contact-label">WhatsApp</span>
+            <a href={`https://wa.me/${window.SITE.whatsapp}`} className="contact-value" data-cursor="hover">{window.SITE.phone}</a>
+          </div>
+          <div className="contact-block reveal">
+            <span className="contact-label">Lokalita</span>
+            <span className="contact-value">Praha a okolí</span>
+          </div>
+        </div>
+        <div className="reveal" style={{ marginTop: 'var(--space-3)', display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+          <a href={`mailto:${window.SITE.email}`} className="btn btn-accent" data-cursor="accent" data-cursor-label="Send">
+            Získat nezávaznou kalkulaci <span className="btn-arrow"></span>
+          </a>
+          <a href={`https://wa.me/${window.SITE.whatsapp}`} className="btn btn-outline" data-cursor="hover">
+            Napsat na WhatsApp <span className="btn-arrow"></span>
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ============================================
+// FOOTER
+// ============================================
+function Footer() {
+  return (
+    <footer className="footer">
+      <div className="container">
+        <div className="footer-huge">StavPraha</div>
+        <div className="footer-grid">
+          <div>
+            <h6>{window.SITE.companyName}</h6>
+            <p style={{ fontSize: 14, opacity: 0.7, maxWidth: '36ch' }}>{window.SITE.tagline}</p>
+            <p style={{ fontSize: 14, opacity: 0.7, marginTop: 8 }}>{window.SITE.location}</p>
+          </div>
+          <div>
+            <h6>Hlavní služby</h6>
+            <a href="#sluzby">Rekonstrukce bytu</a>
+            <a href="#sluzby">Rekonstrukce koupelny</a>
+            <a href="#sluzby">Obkladačské práce</a>
+            <a href="#sluzby">Elektroinstalace</a>
+            <a href="#sluzby">Rekonstrukce domu</a>
+          </div>
+          <div>
+            <h6>Kontakt</h6>
+            <a href={`tel:${window.SITE.phone}`}>{window.SITE.phone}</a>
+            <a href={`mailto:${window.SITE.email}`}>{window.SITE.email}</a>
+            <a href={`https://wa.me/${window.SITE.whatsapp}`}>WhatsApp</a>
+            <span style={{ fontSize: 14, opacity: 0.7, display: 'block', padding: '4px 0' }}>{window.SITE.address}</span>
+          </div>
+          <div>
+            <h6>Informace</h6>
+            <span style={{ fontSize: 14, opacity: 0.7, display: 'block', padding: '4px 0' }}>IČO: {window.SITE.ico}</span>
+            <span style={{ fontSize: 14, opacity: 0.7, display: 'block', padding: '4px 0' }}>{window.SITE.warrantyText}</span>
+            <a href="#">Ochrana osobních údajů</a>
+          </div>
+        </div>
+        <div className="footer-bottom">
+          <span>© 2026 StavPraha · All rights reserved</span>
+          <span>Redesign · 2026</span>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+Object.assign(window, {
+  Nav, Hero, Marquee, About, Fears, Services, Portfolio, BeforeAfter,
+  Process, Advantages, Calc, Spaces, Reviews, Certs, Team, Partners,
+  Blog, Faq, Contact, Footer,
+});

--- a/v2/styles.css
+++ b/v2/styles.css
@@ -1,0 +1,1379 @@
+/* ============================================
+   STAVPRAHA REDESIGN — readymag-style
+   ============================================ */
+
+:root {
+  /* Theme — overridden by JS for tweaks */
+  --bg: #f6f5f1;
+  --bg-alt: #ece9e2;
+  --fg: #0a0a0a;
+  --fg-muted: rgba(10, 10, 10, 0.55);
+  --fg-faint: rgba(10, 10, 10, 0.12);
+  --accent: #c8553d;
+  --accent-fg: #ffffff;
+
+  /* Density — overridden by JS */
+  --density: 1;
+  --space-1: calc(0.5rem * var(--density));
+  --space-2: calc(1rem * var(--density));
+  --space-3: calc(2rem * var(--density));
+  --space-4: calc(4rem * var(--density));
+  --space-5: calc(8rem * var(--density));
+  --space-6: calc(12rem * var(--density));
+
+  /* Fonts */
+  --font-body: 'Inter', system-ui, sans-serif;
+  --font-display: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+  --display-weight: 700;
+  --display-tracking: -0.04em;
+}
+
+[data-theme="dark"] {
+  --bg: #0a0a0a;
+  --bg-alt: #161616;
+  --fg: #f6f5f1;
+  --fg-muted: rgba(246, 245, 241, 0.55);
+  --fg-faint: rgba(246, 245, 241, 0.12);
+  --accent-fg: #0a0a0a;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 17px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+  cursor: none;
+  transition: background 0.4s ease, color 0.4s ease;
+}
+
+@media (max-width: 768px) {
+  body { cursor: auto; font-size: 16px; }
+  .cursor, .cursor-trail { display: none !important; }
+}
+
+/* ============================================
+   CUSTOM CURSOR
+   ============================================ */
+.cursor {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 10px;
+  height: 10px;
+  background: var(--fg);
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 9999;
+  transform: translate(-50%, -50%);
+  transition: transform 0.18s ease, width 0.25s cubic-bezier(.2,.9,.2,1), height 0.25s cubic-bezier(.2,.9,.2,1), background 0.25s ease, opacity 0.2s ease;
+  mix-blend-mode: difference;
+}
+.cursor.is-hover {
+  width: 64px;
+  height: 64px;
+  background: var(--fg);
+  mix-blend-mode: difference;
+}
+.cursor.is-hover-accent {
+  width: 80px;
+  height: 80px;
+  background: var(--accent);
+  mix-blend-mode: normal;
+  color: var(--accent-fg);
+}
+.cursor.is-text {
+  width: 4px;
+  height: 28px;
+  border-radius: 1px;
+}
+.cursor-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0;
+  white-space: nowrap;
+}
+.cursor.is-hover-accent .cursor-label {
+  opacity: 1;
+}
+.cursor-trail {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--fg);
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 9998;
+  transform: translate(-50%, -50%);
+  transition: transform 0.5s cubic-bezier(.2,.9,.2,1), opacity 0.2s;
+  opacity: 0.3;
+  mix-blend-mode: difference;
+}
+
+/* ============================================
+   SCROLL PROGRESS
+   ============================================ */
+.scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 2px;
+  background: var(--accent);
+  z-index: 1000;
+  transition: width 0.05s linear;
+}
+
+/* ============================================
+   TYPOGRAPHY
+   ============================================ */
+.display {
+  font-family: var(--font-display);
+  font-weight: var(--display-weight);
+  letter-spacing: var(--display-tracking);
+  line-height: 0.92;
+}
+
+.mono {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 500;
+}
+
+.huge {
+  font-size: clamp(64px, 13vw, 220px);
+}
+
+.big {
+  font-size: clamp(48px, 8vw, 128px);
+}
+
+.medium {
+  font-size: clamp(36px, 5vw, 72px);
+}
+
+.serif-toggle {
+  font-style: italic;
+}
+
+/* ============================================
+   LAYOUT
+   ============================================ */
+.container {
+  width: 100%;
+  max-width: 1640px;
+  margin: 0 auto;
+  padding: 0 max(24px, calc(var(--space-3)));
+}
+
+section {
+  padding: var(--space-5) 0;
+  position: relative;
+}
+
+.section-label {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: var(--space-3);
+  color: var(--fg-muted);
+}
+.section-label::before {
+  content: '';
+  display: block;
+  width: 32px;
+  height: 1px;
+  background: var(--fg);
+  opacity: 0.5;
+}
+
+/* ============================================
+   NAVBAR
+   ============================================ */
+.nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 100;
+  padding: 20px max(24px, 3vw);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  mix-blend-mode: difference;
+  color: #fff;
+}
+.nav a, .nav button { color: inherit; }
+.nav-logo {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.nav-logo-mark {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  background: currentColor;
+  position: relative;
+  overflow: hidden;
+}
+.nav-logo-mark::before {
+  content: '';
+  position: absolute;
+  inset: 30% 30% 0 30%;
+  background: var(--bg);
+}
+.nav-links {
+  display: flex;
+  gap: 32px;
+  list-style: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.nav-links a {
+  text-decoration: none;
+  position: relative;
+  padding: 6px 0;
+}
+.nav-links a::after {
+  content: '';
+  position: absolute;
+  bottom: 0; left: 0;
+  width: 0;
+  height: 1px;
+  background: currentColor;
+  transition: width 0.3s ease;
+}
+.nav-links a:hover::after { width: 100%; }
+
+.nav-cta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 10px 18px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  text-decoration: none;
+  background: transparent;
+  cursor: none;
+}
+
+@media (max-width: 900px) {
+  .nav-links { display: none; }
+}
+
+/* ============================================
+   HERO
+   ============================================ */
+.hero {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  padding-top: 100px;
+  padding-bottom: var(--space-4);
+  position: relative;
+  overflow: hidden;
+}
+.hero-spacer { flex: 1; min-height: 80px; }
+.hero-meta {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-3);
+}
+.hero-title {
+  font-size: clamp(44px, 9vw, 180px);
+  line-height: 0.92;
+  letter-spacing: -0.05em;
+  font-weight: 700;
+  margin-bottom: var(--space-3);
+  max-width: 100%;
+}
+.hero-title em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 500;
+}
+.hero-strip {
+  height: 1px;
+  background: var(--fg);
+  opacity: 0.2;
+  margin: var(--space-3) 0;
+}
+.hero-bottom {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: var(--space-3);
+  align-items: end;
+}
+.hero-sub {
+  font-size: clamp(18px, 1.6vw, 22px);
+  line-height: 1.4;
+  max-width: 560px;
+  color: var(--fg-muted);
+}
+.hero-ctas {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+@media (max-width: 768px) {
+  .hero-bottom { grid-template-columns: 1fr; }
+  .hero-ctas { justify-content: flex-start; }
+}
+
+/* ============================================
+   BUTTONS
+   ============================================ */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 28px;
+  border-radius: 999px;
+  text-decoration: none;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  border: 1px solid var(--fg);
+  background: var(--fg);
+  color: var(--bg);
+  cursor: none;
+  transition: transform 0.3s cubic-bezier(.2,.9,.2,1), background 0.3s, color 0.3s;
+  white-space: nowrap;
+}
+.btn:hover { transform: translateY(-2px); }
+.btn-outline {
+  background: transparent;
+  color: var(--fg);
+}
+.btn-accent {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+.btn-arrow {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  position: relative;
+}
+.btn-arrow::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-top: 1px solid currentColor;
+  border-right: 1px solid currentColor;
+  transform: rotate(45deg);
+}
+
+/* ============================================
+   MARQUEE
+   ============================================ */
+.marquee {
+  overflow: hidden;
+  padding: var(--space-3) 0;
+  border-top: 1px solid var(--fg-faint);
+  border-bottom: 1px solid var(--fg-faint);
+}
+.marquee-track {
+  display: flex;
+  gap: 60px;
+  animation: marquee 40s linear infinite;
+  white-space: nowrap;
+}
+.marquee-item {
+  font-size: clamp(48px, 7vw, 96px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  display: flex;
+  align-items: center;
+  gap: 60px;
+}
+.marquee-item::after {
+  content: '✺';
+  display: inline-block;
+  color: var(--accent);
+  font-weight: 400;
+  animation: spin 8s linear infinite;
+}
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+@keyframes spin {
+  from { transform: rotate(0); }
+  to { transform: rotate(360deg); }
+}
+
+/* ============================================
+   ABOUT — split text
+   ============================================ */
+.about-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: var(--space-4);
+  align-items: start;
+}
+.about-lead {
+  font-size: clamp(28px, 3.2vw, 48px);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+}
+.about-lead em {
+  font-style: italic;
+  color: var(--accent);
+}
+.about-side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.about-stat {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 24px;
+  align-items: baseline;
+  border-top: 1px solid var(--fg-faint);
+  padding-top: 20px;
+}
+.about-stat-num {
+  font-size: 48px;
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
+}
+.about-stat-num em {
+  color: var(--accent);
+  font-style: normal;
+}
+.about-stat-label {
+  font-size: 14px;
+  color: var(--fg-muted);
+  line-height: 1.4;
+}
+@media (max-width: 900px) {
+  .about-grid { grid-template-columns: 1fr; }
+}
+
+/* ============================================
+   FEARS / VALUES — list with hover reveal
+   ============================================ */
+.list-rows {
+  border-top: 1px solid var(--fg-faint);
+}
+.list-row {
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
+  align-items: center;
+  gap: 32px;
+  padding: 28px 0;
+  border-bottom: 1px solid var(--fg-faint);
+  cursor: none;
+  transition: padding-left 0.4s cubic-bezier(.2,.9,.2,1), color 0.3s;
+  position: relative;
+}
+.list-row:hover {
+  padding-left: 24px;
+}
+.list-row:hover .list-row-num {
+  color: var(--accent);
+}
+.list-row-num {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-muted);
+  transition: color 0.3s;
+}
+.list-row-text {
+  font-size: clamp(20px, 2.2vw, 32px);
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+.list-row-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  opacity: 0;
+  transform: translateX(-12px);
+  transition: opacity 0.4s, transform 0.4s;
+}
+.list-row:hover .list-row-meta {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* ============================================
+   SERVICES — broken grid w/ hover img
+   ============================================ */
+.services-list {
+  border-top: 1px solid var(--fg);
+}
+.service-item {
+  display: grid;
+  grid-template-columns: 60px 1fr 1fr 1fr;
+  gap: 32px;
+  padding: 32px 0;
+  border-bottom: 1px solid var(--fg-faint);
+  position: relative;
+  align-items: center;
+  cursor: none;
+  transition: background 0.4s, color 0.4s, padding 0.4s;
+}
+.service-item:hover {
+  background: var(--fg);
+  color: var(--bg);
+  padding: 32px 24px;
+  margin: 0 -24px;
+}
+.service-item:hover .service-num {
+  color: var(--accent);
+}
+.service-num {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-muted);
+  transition: color 0.3s;
+}
+.service-name {
+  font-size: clamp(28px, 3.2vw, 52px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+.service-desc {
+  font-size: 14px;
+  color: var(--fg-muted);
+  line-height: 1.4;
+  max-width: 280px;
+}
+.service-item:hover .service-desc { color: rgba(255,255,255,0.7); }
+.service-tags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.service-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 6px 12px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  opacity: 0.6;
+}
+.service-preview {
+  position: fixed;
+  pointer-events: none;
+  width: 320px;
+  height: 220px;
+  z-index: 50;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.3s, transform 0.3s;
+  overflow: hidden;
+}
+.service-preview.active {
+  opacity: 1;
+  transform: scale(1);
+}
+.service-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+@media (max-width: 900px) {
+  .service-item { grid-template-columns: 40px 1fr; }
+  .service-desc, .service-tags { display: none; }
+}
+
+/* ============================================
+   PORTFOLIO — large image cards
+   ============================================ */
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 24px;
+}
+.port-card {
+  position: relative;
+  overflow: hidden;
+  background: var(--bg-alt);
+  cursor: none;
+}
+.port-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 1.2s cubic-bezier(.2,.9,.2,1);
+}
+.port-card:hover img { transform: scale(1.04); }
+.port-1 { grid-column: span 7; aspect-ratio: 4/3; }
+.port-2 { grid-column: span 5; aspect-ratio: 4/5; margin-top: var(--space-4); }
+.port-3 { grid-column: span 5; aspect-ratio: 4/5; }
+.port-4 { grid-column: span 7; aspect-ratio: 4/3; margin-top: var(--space-4); }
+.port-card-meta {
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  padding: 24px;
+  background: linear-gradient(transparent, rgba(0,0,0,0.6));
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+}
+.port-card-title {
+  font-size: clamp(18px, 1.8vw, 24px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.port-card-tag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+@media (max-width: 768px) {
+  .port-1, .port-2, .port-3, .port-4 { grid-column: span 12; margin-top: 0; aspect-ratio: 4/3; }
+}
+
+/* ============================================
+   BEFORE / AFTER SLIDER
+   ============================================ */
+.ba-wrap {
+  position: relative;
+  aspect-ratio: 16/9;
+  overflow: hidden;
+  user-select: none;
+  cursor: none;
+}
+.ba-wrap img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.ba-after-clip {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+.ba-handle {
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 2px;
+  background: var(--accent);
+  pointer-events: none;
+}
+.ba-handle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--accent);
+  display: flex;
+}
+.ba-handle::after {
+  content: '↔';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: var(--accent-fg);
+  font-size: 20px;
+  z-index: 2;
+}
+.ba-label {
+  position: absolute;
+  top: 16px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #fff;
+  background: rgba(0,0,0,0.5);
+  padding: 6px 12px;
+  backdrop-filter: blur(8px);
+}
+
+/* ============================================
+   PROCESS — step list
+   ============================================ */
+.process {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+}
+.process-side {
+  position: sticky;
+  top: 120px;
+  align-self: start;
+}
+.process-side h2 {
+  font-size: clamp(40px, 5vw, 80px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+}
+.process-side h2 em {
+  font-style: italic;
+  color: var(--accent);
+}
+.process-steps {
+  display: flex;
+  flex-direction: column;
+}
+.process-step {
+  padding: 32px 0;
+  border-bottom: 1px solid var(--fg-faint);
+}
+.process-step:first-child { padding-top: 0; }
+.process-step-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12px;
+}
+.process-step-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  letter-spacing: 0.12em;
+}
+.process-step-title {
+  font-size: clamp(22px, 2.4vw, 32px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-bottom: 10px;
+}
+.process-step-text {
+  color: var(--fg-muted);
+  font-size: 16px;
+  line-height: 1.5;
+}
+@media (max-width: 900px) {
+  .process { grid-template-columns: 1fr; }
+  .process-side { position: relative; top: 0; }
+}
+
+/* ============================================
+   CALCULATOR
+   ============================================ */
+.calc {
+  background: var(--fg);
+  color: var(--bg);
+  padding: var(--space-4);
+  border-radius: 2px;
+}
+.calc-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-4);
+  align-items: start;
+}
+.calc-head h2 {
+  font-size: clamp(40px, 5vw, 80px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 0.95;
+}
+.calc-head h2 em {
+  font-style: italic;
+  color: var(--accent);
+}
+.calc-head p {
+  margin-top: var(--space-2);
+  color: rgba(255,255,255,0.6);
+  max-width: 420px;
+}
+[data-theme="dark"] .calc { background: var(--bg-alt); color: var(--fg); }
+[data-theme="dark"] .calc-head p { color: var(--fg-muted); }
+
+.calc-form { display: flex; flex-direction: column; gap: var(--space-2); }
+.calc-field { display: flex; flex-direction: column; gap: 8px; }
+.calc-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255,255,255,0.5);
+}
+[data-theme="dark"] .calc-label { color: var(--fg-muted); }
+.calc-select-row {
+  display: flex;
+  gap: 8px;
+}
+.calc-chip {
+  flex: 1;
+  padding: 14px 18px;
+  border: 1px solid rgba(255,255,255,0.2);
+  background: transparent;
+  color: inherit;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  cursor: none;
+  border-radius: 999px;
+  transition: all 0.3s;
+}
+[data-theme="dark"] .calc-chip { border-color: var(--fg-faint); }
+.calc-chip.active {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+}
+.calc-input {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid rgba(255,255,255,0.2);
+  color: inherit;
+  font-size: clamp(40px, 5vw, 72px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  padding: 12px 0;
+  outline: none;
+  font-family: inherit;
+}
+[data-theme="dark"] .calc-input { border-color: var(--fg-faint); }
+.calc-input:focus {
+  border-color: var(--accent);
+}
+.calc-result {
+  margin-top: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid rgba(255,255,255,0.2);
+}
+[data-theme="dark"] .calc-result { border-color: var(--fg-faint); }
+.calc-result-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255,255,255,0.5);
+}
+[data-theme="dark"] .calc-result-label { color: var(--fg-muted); }
+.calc-result-value {
+  font-size: clamp(40px, 6vw, 84px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  margin-top: 12px;
+}
+.calc-result-value em {
+  font-style: italic;
+  color: var(--accent);
+}
+.calc-note {
+  font-size: 12px;
+  color: rgba(255,255,255,0.4);
+  margin-top: 16px;
+}
+[data-theme="dark"] .calc-note { color: var(--fg-muted); }
+
+@media (max-width: 900px) {
+  .calc-grid { grid-template-columns: 1fr; }
+}
+
+/* ============================================
+   REVIEWS / TESTIMONIALS
+   ============================================ */
+.reviews {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--fg-faint);
+  border-bottom: 1px solid var(--fg-faint);
+}
+.review {
+  padding: var(--space-3);
+  border-right: 1px solid var(--fg-faint);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+.review:last-child { border-right: none; }
+.review-quote-mark {
+  font-size: 80px;
+  line-height: 0.5;
+  color: var(--accent);
+  font-family: serif;
+  height: 20px;
+}
+.review-text {
+  font-size: clamp(18px, 1.8vw, 24px);
+  letter-spacing: -0.01em;
+  line-height: 1.35;
+  flex: 1;
+}
+.review-author {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.review-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--bg-alt);
+  overflow: hidden;
+}
+.review-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.review-author-name { font-weight: 600; font-size: 14px; }
+.review-author-stage {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+@media (max-width: 900px) {
+  .reviews { grid-template-columns: 1fr; }
+  .review { border-right: none; border-bottom: 1px solid var(--fg-faint); }
+}
+
+/* ============================================
+   CERTIFICATES
+   ============================================ */
+.certs-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.cert {
+  aspect-ratio: 3/4;
+  background: var(--bg-alt);
+  position: relative;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transition: transform 0.4s;
+  cursor: none;
+}
+.cert:hover { transform: translateY(-6px); }
+.cert-icon {
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--fg);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 14px;
+}
+.cert-name {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+.cert-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--fg-muted);
+  margin-top: 8px;
+}
+@media (max-width: 768px) {
+  .certs-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* ============================================
+   TEAM
+   ============================================ */
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+}
+.team-card { cursor: none; }
+.team-photo {
+  aspect-ratio: 3/4;
+  background: var(--bg-alt);
+  overflow: hidden;
+  margin-bottom: 16px;
+  position: relative;
+  filter: grayscale(1);
+  transition: filter 0.5s;
+}
+.team-card:hover .team-photo { filter: grayscale(0); }
+.team-photo img { width: 100%; height: 100%; object-fit: cover; transition: transform 1s cubic-bezier(.2,.9,.2,1); }
+.team-card:hover .team-photo img { transform: scale(1.05); }
+.team-name { font-size: 18px; font-weight: 600; letter-spacing: -0.01em; }
+.team-role {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-top: 4px;
+}
+@media (max-width: 768px) {
+  .team-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* ============================================
+   BLOG
+   ============================================ */
+.blog-list { border-top: 1px solid var(--fg-faint); }
+.blog-item {
+  display: grid;
+  grid-template-columns: 100px 1fr 2fr 100px;
+  gap: 32px;
+  padding: 32px 0;
+  border-bottom: 1px solid var(--fg-faint);
+  align-items: center;
+  cursor: none;
+  transition: padding-left 0.4s cubic-bezier(.2,.9,.2,1);
+}
+.blog-item:hover { padding-left: 24px; }
+.blog-date {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.blog-cat {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.blog-title {
+  font-size: clamp(20px, 2vw, 28px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+.blog-arrow { justify-self: end; }
+@media (max-width: 768px) {
+  .blog-item { grid-template-columns: 80px 1fr; gap: 16px; }
+  .blog-cat, .blog-arrow { display: none; }
+}
+
+/* ============================================
+   FAQ
+   ============================================ */
+.faq-grid {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: var(--space-4);
+  align-items: start;
+}
+.faq-list { border-top: 1px solid var(--fg-faint); }
+.faq-item {
+  border-bottom: 1px solid var(--fg-faint);
+  padding: 28px 0;
+  cursor: none;
+}
+.faq-q {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 24px;
+}
+.faq-q-text {
+  font-size: clamp(18px, 1.8vw, 24px);
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
+}
+.faq-toggle {
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--fg);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+  transition: transform 0.4s, background 0.3s, color 0.3s;
+}
+.faq-item.open .faq-toggle {
+  transform: rotate(45deg);
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+.faq-a {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.5s cubic-bezier(.2,.9,.2,1);
+  color: var(--fg-muted);
+}
+.faq-item.open .faq-a {
+  max-height: 320px;
+}
+.faq-a-inner { padding-top: 16px; line-height: 1.5; }
+
+@media (max-width: 900px) {
+  .faq-grid { grid-template-columns: 1fr; }
+}
+
+/* ============================================
+   CONTACT
+   ============================================ */
+.contact-hero {
+  font-size: clamp(56px, 9vw, 160px);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+  line-height: 0.9;
+  margin-bottom: var(--space-3);
+}
+.contact-hero em { font-style: italic; color: var(--accent); }
+.contact-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 32px;
+  border-top: 1px solid var(--fg-faint);
+  padding-top: var(--space-3);
+}
+.contact-block { display: flex; flex-direction: column; gap: 8px; }
+.contact-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.contact-value {
+  font-size: clamp(18px, 1.6vw, 22px);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  text-decoration: none;
+  color: var(--fg);
+}
+.contact-value:hover { color: var(--accent); }
+
+@media (max-width: 768px) {
+  .contact-grid { grid-template-columns: 1fr 1fr; }
+}
+
+/* ============================================
+   FOOTER
+   ============================================ */
+.footer {
+  background: var(--fg);
+  color: var(--bg);
+  padding: var(--space-4) 0 var(--space-3);
+}
+.footer-huge {
+  font-size: clamp(80px, 18vw, 320px);
+  font-weight: 700;
+  letter-spacing: -0.05em;
+  line-height: 0.85;
+  border-bottom: 1px solid rgba(255,255,255,0.15);
+  padding-bottom: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+[data-theme="dark"] .footer-huge { border-color: var(--fg-faint); }
+.footer-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 32px;
+  margin-bottom: var(--space-3);
+}
+.footer h6 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 12px;
+  color: rgba(255,255,255,0.5);
+}
+[data-theme="dark"] .footer h6 { color: var(--fg-muted); }
+.footer a {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+  padding: 4px 0;
+  font-size: 14px;
+}
+.footer-bottom {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: rgba(255,255,255,0.5);
+  padding-top: var(--space-2);
+  border-top: 1px solid rgba(255,255,255,0.15);
+}
+[data-theme="dark"] .footer-bottom {
+  color: var(--fg-muted);
+  border-color: var(--fg-faint);
+}
+@media (max-width: 768px) {
+  .footer-grid { grid-template-columns: 1fr 1fr; }
+  .footer-bottom { flex-direction: column; gap: 12px; }
+}
+
+/* ============================================
+   PARTNERS
+   ============================================ */
+.partners {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  border: 1px solid var(--fg-faint);
+}
+.partner-box {
+  aspect-ratio: 2/1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-right: 1px solid var(--fg-faint);
+  border-bottom: 1px solid var(--fg-faint);
+  padding: 24px;
+  transition: background 0.3s;
+}
+.partner-box:hover { background: var(--bg-alt); }
+.partner-box:nth-child(4n) { border-right: none; }
+.partner-box:nth-last-child(-n+4) { border-bottom: none; }
+.partner-box span {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--fg-muted);
+  text-align: center;
+}
+@media (max-width: 768px) {
+  .partners { grid-template-columns: repeat(2, 1fr); }
+  .partner-box { border-right: 1px solid var(--fg-faint) !important; }
+  .partner-box:nth-child(2n) { border-right: none !important; }
+}
+
+/* ============================================
+   SPACES
+   ============================================ */
+.spaces-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 12px;
+}
+.space-chip {
+  aspect-ratio: 1;
+  border: 1px solid var(--fg-faint);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  text-align: center;
+  padding: 16px;
+  transition: background 0.3s, color 0.3s, border-color 0.3s;
+  cursor: none;
+}
+.space-chip:hover {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: var(--accent);
+}
+.space-glyph {
+  font-size: 28px;
+  font-weight: 300;
+}
+.space-name { font-size: 13px; font-weight: 500; }
+@media (max-width: 900px) {
+  .spaces-grid { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width: 500px) {
+  .spaces-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* ============================================
+   ANIMATIONS — reveal on scroll
+   ============================================ */
+.reveal {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.9s cubic-bezier(.2,.9,.2,1), transform 0.9s cubic-bezier(.2,.9,.2,1);
+}
+.reveal[data-hidden="1"] {
+  opacity: 0;
+  transform: translateY(40px);
+}
+.reveal-letters span {
+  display: inline-block;
+  opacity: 0;
+  transform: translateY(0.3em);
+  transition: opacity 0.5s, transform 0.5s cubic-bezier(.2,.9,.2,1);
+}
+.reveal-letters.is-visible span {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Floating WhatsApp */
+.wa-float {
+  position: fixed;
+  bottom: 32px;
+  right: 32px;
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: #25d366;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 90;
+  text-decoration: none;
+  font-size: 28px;
+  cursor: none;
+  transition: transform 0.3s;
+}
+.wa-float:hover { transform: scale(1.1); }
+
+/* Tweaks panel override — has cursor */
+.tweaks-panel * { cursor: auto; }

--- a/v2/tweaks-panel.jsx
+++ b/v2/tweaks-panel.jsx
@@ -1,0 +1,568 @@
+
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "palette": ["#D97757", "#29261b", "#f6f4ef"],
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        options={['#D97757', '#2A6FDB', '#1F8A5B', '#7A5AE0']}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakColor  label="Palette" value={t.palette}
+//                        options={[['#D97757', '#29261b', '#f6f4ef'],
+//                                  ['#475569', '#0f172a', '#f1f5f9']]}
+//                        onChange={(v) => setTweak('palette', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom right;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;box-sizing:border-box;width:100%;min-width:0;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;box-sizing:border-box;min-width:0;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+
+  .twk-chips{display:flex;gap:6px}
+  .twk-chip{position:relative;appearance:none;flex:1;min-width:0;height:46px;
+    padding:0;border:0;border-radius:6px;overflow:hidden;cursor:default;
+    box-shadow:0 0 0 .5px rgba(0,0,0,.12),0 1px 2px rgba(0,0,0,.06);
+    transition:transform .12s cubic-bezier(.3,.7,.4,1),box-shadow .12s}
+  .twk-chip:hover{transform:translateY(-1px);
+    box-shadow:0 0 0 .5px rgba(0,0,0,.18),0 4px 10px rgba(0,0,0,.12)}
+  .twk-chip[data-on="1"]{box-shadow:0 0 0 1.5px rgba(0,0,0,.85),
+    0 2px 6px rgba(0,0,0,.15)}
+  .twk-chip>span{position:absolute;top:0;bottom:0;right:0;width:34%;
+    display:flex;flex-direction:column;box-shadow:-1px 0 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i{flex:1;box-shadow:0 -1px 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i:first-child{box-shadow:none}
+  .twk-chip svg{position:absolute;top:6px;left:6px;width:13px;height:13px;
+    filter:drop-shadow(0 1px 1px rgba(0,0,0,.3))}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+    // Same-window signal so in-page listeners (deck-stage rail thumbnails)
+    // can react — the parent message only reaches the host, not peers.
+    window.dispatchEvent(new CustomEvent('tweakchange', { detail: edits }));
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', noDeckControls = false, children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  // Auto-inject a rail toggle when a <deck-stage> is on the page. The
+  // toggle drives the deck's per-viewer _railVisible via window message;
+  // state is mirrored from the same localStorage key the deck reads so
+  // the control reflects reality across reloads. The mechanism is the
+  // message — authors who want custom placement can post it directly
+  // and pass noDeckControls to suppress this one.
+  const hasDeckStage = React.useMemo(
+    () => typeof document !== 'undefined' && !!document.querySelector('deck-stage'),
+    [],
+  );
+  // deck-stage enables its rail in connectedCallback, but this panel can
+  // mount before that element has upgraded. The initial read catches the
+  // common case; the listener covers mounting first. (Older deck-stage.js
+  // copies still wait for the host's __omelette_rail_enabled postMessage —
+  // same listener handles those.)
+  const [railEnabled, setRailEnabled] = React.useState(
+    () => hasDeckStage && !!document.querySelector('deck-stage')?._railEnabled,
+  );
+  React.useEffect(() => {
+    if (!hasDeckStage || railEnabled) return undefined;
+    const onMsg = (e) => {
+      if (e.data && e.data.type === '__omelette_rail_enabled') setRailEnabled(true);
+    };
+    window.addEventListener('message', onMsg);
+    return () => window.removeEventListener('message', onMsg);
+  }, [hasDeckStage, railEnabled]);
+  const [railVisible, setRailVisible] = React.useState(() => {
+    try { return localStorage.getItem('deck-stage.railVisible') !== '0'; } catch (e) { return true; }
+  });
+  const toggleRail = (on) => {
+    setRailVisible(on);
+    window.postMessage({ type: '__deck_rail_visible', on }, '*');
+  };
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel" data-noncommentable=""
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">
+          {children}
+          {hasDeckStage && railEnabled && !noDeckControls && (
+            <TweakSection label="Deck">
+              <TweakToggle label="Thumbnail rail" value={railVisible} onChange={toggleRail} />
+            </TweakSection>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  // Segments wrap mid-word once per-segment width runs out. The track is
+  // ~248px (280 panel − 28 body pad − 4 seg pad), each button loses 12px
+  // to its own padding, and 11.5px system-ui averages ~6.3px/char — so 2
+  // options fit ~16 chars each, 3 fit ~10. Past that (or >3 options), fall
+  // back to a dropdown rather than wrap.
+  const labelLen = (o) => String(typeof o === 'object' ? o.label : o).length;
+  const maxLen = options.reduce((m, o) => Math.max(m, labelLen(o)), 0);
+  const fitsAsSegments = maxLen <= ({ 2: 16, 3: 10 }[options.length] ?? 0);
+  if (!fitsAsSegments) {
+    // <select> emits strings — map back to the original option value so the
+    // fallback stays type-preserving (numbers, booleans) like the segment path.
+    const resolve = (s) => {
+      const m = options.find((o) => String(typeof o === 'object' ? o.value : o) === s);
+      return m === undefined ? s : typeof m === 'object' ? m.value : m;
+    };
+    return <TweakSelect label={label} value={value} options={options}
+                        onChange={(s) => onChange(resolve(s))} />;
+  }
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+// Relative-luminance contrast pick — checkmarks drawn over a swatch need to
+// read on both #111 and #fafafa without per-option configuration. Hex input
+// only (#rgb / #rrggbb); named or rgb()/hsl() colors fall through to "light".
+function __twkIsLight(hex) {
+  const h = String(hex).replace('#', '');
+  const x = h.length === 3 ? h.replace(/./g, (c) => c + c) : h.padEnd(6, '0');
+  const n = parseInt(x.slice(0, 6), 16);
+  if (Number.isNaN(n)) return true;
+  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+  return r * 299 + g * 587 + b * 114 > 148000;
+}
+
+const __TwkCheck = ({ light }) => (
+  <svg viewBox="0 0 14 14" aria-hidden="true">
+    <path d="M3 7.2 5.8 10 11 4.2" fill="none" strokeWidth="2.2"
+          strokeLinecap="round" strokeLinejoin="round"
+          stroke={light ? 'rgba(0,0,0,.78)' : '#fff'} />
+  </svg>
+);
+
+// TweakColor — curated color/palette picker. Each option is either a single
+// hex string or an array of 1-5 hex strings; the card adapts — a lone color
+// renders solid, a palette renders colors[0] as the hero (left ~2/3) with the
+// rest stacked in a sharp column on the right. onChange emits the
+// option in the shape it was passed (string stays string, array stays array).
+// Without options it falls back to the native color input for back-compat.
+function TweakColor({ label, value, options, onChange }) {
+  if (!options || !options.length) {
+    return (
+      <div className="twk-row twk-row-h">
+        <div className="twk-lbl"><span>{label}</span></div>
+        <input type="color" className="twk-swatch" value={value}
+               onChange={(e) => onChange(e.target.value)} />
+      </div>
+    );
+  }
+  // Native <input type=color> emits lowercase hex per the HTML spec, so
+  // compare case-insensitively. String() guards JSON.stringify(undefined),
+  // which returns the primitive undefined (no .toLowerCase).
+  const key = (o) => String(JSON.stringify(o)).toLowerCase();
+  const cur = key(value);
+  return (
+    <TweakRow label={label}>
+      <div className="twk-chips" role="radiogroup">
+        {options.map((o, i) => {
+          const colors = Array.isArray(o) ? o : [o];
+          const [hero, ...rest] = colors;
+          const sup = rest.slice(0, 4);
+          const on = key(o) === cur;
+          return (
+            <button key={i} type="button" className="twk-chip" role="radio"
+                    aria-checked={on} data-on={on ? '1' : '0'}
+                    aria-label={colors.join(', ')} title={colors.join(' · ')}
+                    style={{ background: hero }}
+                    onClick={() => onChange(o)}>
+              {sup.length > 0 && (
+                <span>
+                  {sup.map((c, j) => <i key={j} style={{ background: c }} />)}
+                </span>
+              )}
+              {on && <__TwkCheck light={__twkIsLight(hero)} />}
+            </button>
+          );
+        })}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});


### PR DESCRIPTION
## Summary
- Drops the redesigned StavPraha site into `/v2/` as a standalone preview, so the live site stays exactly as it is today.
- Adds a slim gradient banner above the navbar on the homepage linking to `/v2/` (label: "Vyzkoušejte naši novou verzi webu") with a "NOVÉ" badge.
- New version is a React + Babel-standalone build that runs straight from static files — no build step needed, GitHub Pages serves it as-is at `stavpraha.com/v2/`.

## Test plan
- [ ] Open `stavpraha.com` after merge and confirm the blue banner appears at the very top of the homepage.
- [ ] Click the banner and confirm it navigates to `stavpraha.com/v2/` and the new design loads correctly (React hydrates, styles applied).
- [ ] Confirm the rest of the old site (navbar, hero, services pages) is unchanged.
- [ ] Check mobile rendering of the banner (should shrink padding/font under 480px).

🤖 Generated with [Claude Code](https://claude.com/claude-code)