### PR TITLE
Fix v2 empty-column gap in FAQ/Calc near bottom

### DIFF
--- a/v2/index.html
+++ b/v2/index.html
@@ -8,7 +8,7 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500&family=Instrument+Serif:ital@0;1&family=Space+Grotesk:wght@400;500;600;700&family=Fraunces:ital,wght@0,400;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="styles.css?v=20260519g">
 </head>
 <body>
 <div id="root"></div>

--- a/v2/styles.css
+++ b/v2/styles.css
@@ -814,6 +814,11 @@ section {
   gap: var(--space-4);
   align-items: start;
 }
+.calc-grid > .calc-head {
+  position: sticky;
+  top: 120px;
+  align-self: start;
+}
 .calc-head h2 {
   font-size: clamp(40px, 5vw, 80px);
   font-weight: 700;
@@ -1107,6 +1112,11 @@ section {
   grid-template-columns: 1fr 2fr;
   gap: var(--space-4);
   align-items: start;
+}
+.faq-grid > :first-child {
+  position: sticky;
+  top: 120px;
+  align-self: start;
 }
 .faq-list { border-top: 1px solid var(--fg-faint); }
 .faq-item {


### PR DESCRIPTION
## Summary
The FAQ section on /v2/ has a 1fr 2fr grid — a short heading column on the left and a tall question list on the right. As the user scrolled past the heading, the left column went empty for ~480px before the section ended, easily perceived as "the page disappeared" near the bottom.

This pins the heading column with `position: sticky; top: 120px` so it stays in view while the questions scroll past — the same pattern already used by the Process section.

Applied the same fix to the Calculator section's heading column (292px vs 441px gap — smaller but still visible).

## Test plan
- [ ] Open `stavpraha.com/v2/` and scroll down to the FAQ section. Verify the "Časté otázky." / "Frequent questions." heading stays pinned on the left as you scroll through the questions.
- [ ] Scroll further to the Calc section — heading "Orientační cena" / "Estimated price" should also stay pinned while the form scrolls.
- [ ] No visual changes elsewhere on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)