### PR TITLE
Fix v2 blank-screen race on fast scroll

### DIFF
--- a/v2/cursor.jsx
+++ b/v2/cursor.jsx
@@ -94,16 +94,29 @@ function ScrollProgress() {
   return <div ref={ref} className="scroll-progress"></div>;
 }
 
-// Reveal — sets data-hidden initially then removes on intersect.
-// Uses data-attribute (not className) to avoid React reconciliation wiping it.
+// Reveal — sets data-hidden initially on below-the-fold items, then removes
+// on intersect. Uses data-attribute (not className) to avoid React reconciliation
+// wiping it. A scroll listener acts as a fast-scroll safety net so the user
+// can't out-scroll the IntersectionObserver and end up with a blank page.
 function useReveal() {
   useEffect(() => {
     const els = Array.from(document.querySelectorAll('.reveal, .reveal-letters'));
-    // Tag everything as hidden first
-    els.forEach(el => el.setAttribute('data-hidden', '1'));
     const reveal = (el) => {
       el.removeAttribute('data-hidden');
       el.classList.add('is-visible');
+    };
+    const isNearOrInView = (el) => {
+      const r = el.getBoundingClientRect();
+      return r.top < window.innerHeight + 100 && r.bottom > -100;
+    };
+    // Only hide elements that aren't already in or near the viewport — anything
+    // visible on first paint stays visible immediately (no opacity flash).
+    els.forEach(el => { if (!isNearOrInView(el)) el.setAttribute('data-hidden', '1'); });
+    const checkInView = () => {
+      els.forEach(el => {
+        if (!el.hasAttribute('data-hidden')) return;
+        if (isNearOrInView(el)) reveal(el);
+      });
     };
     const observer = new IntersectionObserver((entries) => {
       entries.forEach(entry => {
@@ -111,21 +124,28 @@ function useReveal() {
       });
     }, { threshold: 0.01, rootMargin: '0px 0px 100px 0px' });
     els.forEach(el => observer.observe(el));
-    const checkInView = () => {
-      els.forEach(el => {
-        if (!el.hasAttribute('data-hidden')) return;
-        const r = el.getBoundingClientRect();
-        if (r.top < window.innerHeight + 100 && r.bottom > -100) reveal(el);
-      });
+    // Fast-scroll safety net: rAF-throttled scroll handler reveals anything
+    // the user scrolls toward, even when the IntersectionObserver hasn't fired
+    // yet (which can happen during very fast scrolls).
+    let scrollRaf = null;
+    const onScroll = () => {
+      if (scrollRaf) return;
+      scrollRaf = requestAnimationFrame(() => { scrollRaf = null; checkInView(); });
     };
-    // Defer initial check so paint commits the hidden state first
+    window.addEventListener('scroll', onScroll, { passive: true });
+    // Run a few times early in case IO doesn't fire for above-the-fold items.
     requestAnimationFrame(() => requestAnimationFrame(checkInView));
+    setTimeout(checkInView, 100);
     setTimeout(checkInView, 300);
-    // Last-resort safety: anything still hidden after 2s, show it
+    // Final hard safety net: anything still hidden after 1s, just show it.
     setTimeout(() => {
       els.forEach(el => el.hasAttribute('data-hidden') && reveal(el));
-    }, 2000);
-    return () => observer.disconnect();
+    }, 1000);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('scroll', onScroll);
+      if (scrollRaf) cancelAnimationFrame(scrollRaf);
+    };
   }, []);
 }
 


### PR DESCRIPTION
## Summary
On `/v2/`, scrolling very fast right after page load caused large portions of the page to render blank — the reveal-animation hook tagged every `.reveal` element with `data-hidden` (opacity:0) on mount, relying on IntersectionObserver to remove the tag. Fast scrolls outran the IO, leaving sections invisible until the 2-second safety net kicked in. User read it as "the whole site disappears."

## Changes
- Don't hide elements that are already in/near the viewport on mount — no opacity flash for above-the-fold content.
- Add a rAF-throttled scroll listener that reveals anything the user scrolls toward, even when the IntersectionObserver hasn't caught up.
- Tighten the safety net from 2s to 1s and add earlier `checkInView` passes at 100ms / 300ms so any timing slip is recovered quickly.

## Test plan
- [ ] Reload `stavpraha.com/v2/` and immediately scroll to the bottom as fast as possible — no blank stretches, no missing sections.
- [ ] Slow scroll still triggers the reveal animation on below-the-fold sections.
- [ ] Repeat on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)